### PR TITLE
Added numba to Python. Changed Python 3.9 on Python 3.8

### DIFF
--- a/clients/Python/Dockerfile
+++ b/clients/Python/Dockerfile
@@ -1,6 +1,12 @@
-FROM python:3.9
+FROM python:3.8
 
-RUN pip install numpy cython sklearn lightgbm catboost
+# Setup env
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONFAULTHANDLER 1
+
+RUN pip install numpy cython sklearn lightgbm catboost numba
 
 COPY . /project
 WORKDIR /project
+


### PR DESCRIPTION
Добавляет jit компилятор [numba](https://numba.pydata.org/) для СPython, который ускоряет код до уровня с++. Работает с версиями Python меньше чем 3.9, замена на 3.8 также исключает пересборку других пакетов.