### PR TITLE
Added `itertools` crate to Rust to support more functional tricks

### DIFF
--- a/clients/Rust/Cargo.toml
+++ b/clients/Rust/Cargo.toml
@@ -8,3 +8,4 @@ model = { path = "model", package = "aicup2020-model" }
 trans = "0.4.0-alpha.3"
 rand = "0.7.3"
 chrono = "0.4.19"
+itertools = "0.9.0"


### PR DESCRIPTION
Is needed to support e.g. cartesian product of iterators