### PR TITLE
Add Java/Kotlin-GraalVM-native client (to solve performance problems with standard Java/Kotlin)

### DIFF
--- a/clients/Java-GraalVM-native/Dockerfile
+++ b/clients/Java-GraalVM-native/Dockerfile
@@ -1,0 +1,20 @@
+FROM oracle/graalvm-ce:20.2.0-java11 AS build-aot
+
+
+RUN gu install native-image
+RUN yum install wget -y
+RUN wget https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /tmp
+RUN tar xf /tmp/apache-maven-3.6.3-bin.tar.gz -C /opt
+RUN ln -s /opt/apache-maven-3.6.3 /opt/maven
+RUN ln -s /opt/graalvm-ce-java11-20.2.0 /opt/graalvm
+
+ENV JAVA_HOME=/opt/graalvm
+ENV M2_HOME=/opt/maven
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${M2_HOME}/bin:${PATH}
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+COPY . /project
+WORKDIR /project
+
+RUN mvn package --batch-mode

--- a/clients/Java-GraalVM-native/compile.sh
+++ b/clients/Java-GraalVM-native/compile.sh
@@ -1,0 +1,13 @@
+set -ex
+
+if [ "$1" != "base" ]; then
+    if [[ `ls -1 /src/ | wc -l` -eq 1 ]]; then
+        cp -f /src/MyStrategy.java src/main/java/MyStrategy.java
+    else
+        rm -rf ./*
+        cp -rf /src/* ./
+    fi
+fi
+
+mvn package --batch-mode
+cp target/aicup2020-native-with-dependencies /output/

--- a/clients/Java-GraalVM-native/pom.xml
+++ b/clients/Java-GraalVM-native/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.codegame.aicup2020.devkit</groupId>
+    <artifactId>aicup2020</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>aicup2020</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+         <graalvm.version>20.2.0</graalvm.version>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>${graalvm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>aicup2020</finalName>
+
+        <plugins>
+         <plugin>
+                <groupId>org.graalvm.nativeimage</groupId>
+                <artifactId>native-image-maven-plugin</artifactId>
+                <version>${graalvm.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>native-image</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>false</skip>
+                    <imageName>aicup2020-native-with-dependencies</imageName>
+                    <buildArgs>
+            --no-fallback
+                    </buildArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>Runner</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/clients/Java-GraalVM-native/run.sh
+++ b/clients/Java-GraalVM-native/run.sh
@@ -1,0 +1,4 @@
+set -ex
+
+cd /output
+./aicup2020-native-with-dependencies "$@"

--- a/clients/Java-GraalVM-native/src/main/java/DebugInterface.java
+++ b/clients/Java-GraalVM-native/src/main/java/DebugInterface.java
@@ -1,0 +1,32 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class DebugInterface {
+    private InputStream inputStream;
+    private OutputStream outputStream;
+
+    public DebugInterface(InputStream inputStream, OutputStream outputStream) {
+        this.inputStream = inputStream;
+        this.outputStream = outputStream;
+    }
+
+    public void send(model.DebugCommand command) {
+        try {
+            new model.ClientMessage.DebugMessage(command).writeTo(outputStream);
+            outputStream.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public model.DebugState getState() {
+        try {
+            new model.ClientMessage.RequestDebugState().writeTo(outputStream);
+            outputStream.flush();
+            return model.DebugState.readFrom(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/MyStrategy.java
+++ b/clients/Java-GraalVM-native/src/main/java/MyStrategy.java
@@ -1,0 +1,60 @@
+import model.*;
+
+public class MyStrategy {
+    public Action getAction(PlayerView playerView, DebugInterface debugInterface) {
+        Action result = new Action(new java.util.HashMap<>());
+        int myId = playerView.getMyId();
+        for (Entity entity : playerView.getEntities()) {
+            if (entity.getPlayerId() == null || entity.getPlayerId() != myId) {
+                continue;
+            }
+            EntityProperties properties = playerView.getEntityProperties().get(entity.getEntityType());
+
+            MoveAction moveAction = null;
+            BuildAction buildAction = null;
+            if (properties.isCanMove()) {
+                moveAction = new MoveAction(
+                    new Vec2Int(playerView.getMapSize() - 1, playerView.getMapSize() - 1),
+                    true,
+                    true);
+            } else if (properties.getBuild() != null) {
+                EntityType entityType = properties.getBuild().getOptions()[0];
+                int currentUnits = 0;
+                for (Entity otherEntity : playerView.getEntities()) {
+                    if (otherEntity.getPlayerId() != null && otherEntity.getPlayerId() == myId
+                        && otherEntity.getEntityType() == entityType) {
+                        currentUnits++;
+                    }
+                }
+                if ((currentUnits + 1) * playerView.getEntityProperties().get(entityType).getPopulationUse() <= properties.getPopulationProvide()) {
+                    buildAction = new BuildAction(
+                        entityType,
+                        new Vec2Int(
+                            entity.getPosition().getX() + properties.getSize(),
+                            entity.getPosition().getY() + properties.getSize() - 1
+                        )
+                    );
+                }
+            }
+            EntityType[] validAutoAttackTargets;
+            if (entity.getEntityType() == EntityType.BUILDER_UNIT) {
+                validAutoAttackTargets = new EntityType[] { EntityType.RESOURCE };
+            } else {
+                validAutoAttackTargets = new EntityType[0];
+            }
+            result.getEntityActions().put(entity.getId(), new EntityAction(
+                moveAction,
+                buildAction,
+                new AttackAction(
+                    null, new AutoAttack(properties.getSightRange(), validAutoAttackTargets)
+                ),
+                null
+            ));
+        }
+        return result;
+    }
+    public void debugUpdate(PlayerView playerView, DebugInterface debugInterface) {
+        debugInterface.send(new DebugCommand.Clear());
+        debugInterface.getState();
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/Runner.java
+++ b/clients/Java-GraalVM-native/src/main/java/Runner.java
@@ -1,0 +1,53 @@
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.BufferedOutputStream;
+
+import util.StreamUtil;
+
+public class Runner {
+    private final InputStream inputStream;
+    private final OutputStream outputStream;
+
+    Runner(String host, int port, String token) throws IOException {
+        Socket socket = new Socket(host, port);
+        socket.setTcpNoDelay(true);
+        inputStream = new BufferedInputStream(socket.getInputStream());
+        outputStream = new BufferedOutputStream(socket.getOutputStream());
+        StreamUtil.writeString(outputStream, token);
+        outputStream.flush();
+    }
+
+    void run() throws IOException {
+        MyStrategy myStrategy = new MyStrategy();
+        DebugInterface debugInterface = new DebugInterface(inputStream, outputStream);
+        while (true) {
+            model.ServerMessage message = model.ServerMessage.readFrom(inputStream);
+            if (message instanceof model.ServerMessage.GetAction) {
+                model.ServerMessage.GetAction getActionMessage = (model.ServerMessage.GetAction) message;
+                new model.ClientMessage.ActionMessage(myStrategy.getAction(getActionMessage.getPlayerView(), getActionMessage.isDebugAvailable() ? debugInterface : null)).writeTo(outputStream);
+                outputStream.flush();
+            } else if (message instanceof model.ServerMessage.Finish) {
+                break;
+            } else if (message instanceof model.ServerMessage.DebugUpdate) {
+                model.ServerMessage.DebugUpdate debugUpdateMessage = (model.ServerMessage.DebugUpdate) message;
+                myStrategy.debugUpdate(debugUpdateMessage.getPlayerView(), debugInterface);
+                new model.ClientMessage.DebugUpdateDone().writeTo(outputStream);
+                outputStream.flush();
+            } else {
+                throw new IOException("Unexpected server message");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        String host = args.length < 1 ? "127.0.0.1" : args[0];
+        int port = args.length < 2 ? 31001 : Integer.parseInt(args[1]);
+        String token = args.length < 3 ? "0000000000000000" : args[2];
+        new Runner(host, port, token).run();
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Action.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Action.java
@@ -1,0 +1,35 @@
+package model;
+
+import util.StreamUtil;
+
+public class Action {
+    private java.util.Map<Integer, model.EntityAction> entityActions;
+    public java.util.Map<Integer, model.EntityAction> getEntityActions() { return entityActions; }
+    public void setEntityActions(java.util.Map<Integer, model.EntityAction> entityActions) { this.entityActions = entityActions; }
+    public Action() {}
+    public Action(java.util.Map<Integer, model.EntityAction> entityActions) {
+        this.entityActions = entityActions;
+    }
+    public static Action readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Action result = new Action();
+        int entityActionsSize = StreamUtil.readInt(stream);
+        result.entityActions = new java.util.HashMap<>(entityActionsSize);
+        for (int i = 0; i < entityActionsSize; i++) {
+            int entityActionsKey;
+            entityActionsKey = StreamUtil.readInt(stream);
+            model.EntityAction entityActionsValue;
+            entityActionsValue = model.EntityAction.readFrom(stream);
+            result.entityActions.put(entityActionsKey, entityActionsValue);
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, entityActions.size());
+        for (java.util.Map.Entry<Integer, model.EntityAction> entityActionsEntry : entityActions.entrySet()) {
+            int entityActionsKey = entityActionsEntry.getKey();
+            model.EntityAction entityActionsValue = entityActionsEntry.getValue();
+            StreamUtil.writeInt(stream, entityActionsKey);
+            entityActionsValue.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/AttackAction.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/AttackAction.java
@@ -1,0 +1,45 @@
+package model;
+
+import util.StreamUtil;
+
+public class AttackAction {
+    private Integer target;
+    public Integer getTarget() { return target; }
+    public void setTarget(Integer target) { this.target = target; }
+    private model.AutoAttack autoAttack;
+    public model.AutoAttack getAutoAttack() { return autoAttack; }
+    public void setAutoAttack(model.AutoAttack autoAttack) { this.autoAttack = autoAttack; }
+    public AttackAction() {}
+    public AttackAction(Integer target, model.AutoAttack autoAttack) {
+        this.target = target;
+        this.autoAttack = autoAttack;
+    }
+    public static AttackAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+        AttackAction result = new AttackAction();
+        if (StreamUtil.readBoolean(stream)) {
+            result.target = StreamUtil.readInt(stream);
+        } else {
+            result.target = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.autoAttack = model.AutoAttack.readFrom(stream);
+        } else {
+            result.autoAttack = null;
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        if (target == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            StreamUtil.writeInt(stream, target);
+        }
+        if (autoAttack == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            autoAttack.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/AttackProperties.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/AttackProperties.java
@@ -1,0 +1,33 @@
+package model;
+
+import util.StreamUtil;
+
+public class AttackProperties {
+    private int attackRange;
+    public int getAttackRange() { return attackRange; }
+    public void setAttackRange(int attackRange) { this.attackRange = attackRange; }
+    private int damage;
+    public int getDamage() { return damage; }
+    public void setDamage(int damage) { this.damage = damage; }
+    private boolean collectResource;
+    public boolean isCollectResource() { return collectResource; }
+    public void setCollectResource(boolean collectResource) { this.collectResource = collectResource; }
+    public AttackProperties() {}
+    public AttackProperties(int attackRange, int damage, boolean collectResource) {
+        this.attackRange = attackRange;
+        this.damage = damage;
+        this.collectResource = collectResource;
+    }
+    public static AttackProperties readFrom(java.io.InputStream stream) throws java.io.IOException {
+        AttackProperties result = new AttackProperties();
+        result.attackRange = StreamUtil.readInt(stream);
+        result.damage = StreamUtil.readInt(stream);
+        result.collectResource = StreamUtil.readBoolean(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, attackRange);
+        StreamUtil.writeInt(stream, damage);
+        StreamUtil.writeBoolean(stream, collectResource);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/AutoAttack.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/AutoAttack.java
@@ -1,0 +1,66 @@
+package model;
+
+import util.StreamUtil;
+
+public class AutoAttack {
+    private int pathfindRange;
+    public int getPathfindRange() { return pathfindRange; }
+    public void setPathfindRange(int pathfindRange) { this.pathfindRange = pathfindRange; }
+    private model.EntityType[] validTargets;
+    public model.EntityType[] getValidTargets() { return validTargets; }
+    public void setValidTargets(model.EntityType[] validTargets) { this.validTargets = validTargets; }
+    public AutoAttack() {}
+    public AutoAttack(int pathfindRange, model.EntityType[] validTargets) {
+        this.pathfindRange = pathfindRange;
+        this.validTargets = validTargets;
+    }
+    public static AutoAttack readFrom(java.io.InputStream stream) throws java.io.IOException {
+        AutoAttack result = new AutoAttack();
+        result.pathfindRange = StreamUtil.readInt(stream);
+        result.validTargets = new model.EntityType[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.validTargets.length; i++) {
+            switch (StreamUtil.readInt(stream)) {
+            case 0:
+                result.validTargets[i] = model.EntityType.WALL;
+                break;
+            case 1:
+                result.validTargets[i] = model.EntityType.HOUSE;
+                break;
+            case 2:
+                result.validTargets[i] = model.EntityType.BUILDER_BASE;
+                break;
+            case 3:
+                result.validTargets[i] = model.EntityType.BUILDER_UNIT;
+                break;
+            case 4:
+                result.validTargets[i] = model.EntityType.MELEE_BASE;
+                break;
+            case 5:
+                result.validTargets[i] = model.EntityType.MELEE_UNIT;
+                break;
+            case 6:
+                result.validTargets[i] = model.EntityType.RANGED_BASE;
+                break;
+            case 7:
+                result.validTargets[i] = model.EntityType.RANGED_UNIT;
+                break;
+            case 8:
+                result.validTargets[i] = model.EntityType.RESOURCE;
+                break;
+            case 9:
+                result.validTargets[i] = model.EntityType.TURRET;
+                break;
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+            }
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, pathfindRange);
+        StreamUtil.writeInt(stream, validTargets.length);
+        for (model.EntityType validTargetsElement : validTargets) {
+            StreamUtil.writeInt(stream, validTargetsElement.tag);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/BuildAction.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/BuildAction.java
@@ -1,0 +1,60 @@
+package model;
+
+import util.StreamUtil;
+
+public class BuildAction {
+    private model.EntityType entityType;
+    public model.EntityType getEntityType() { return entityType; }
+    public void setEntityType(model.EntityType entityType) { this.entityType = entityType; }
+    private model.Vec2Int position;
+    public model.Vec2Int getPosition() { return position; }
+    public void setPosition(model.Vec2Int position) { this.position = position; }
+    public BuildAction() {}
+    public BuildAction(model.EntityType entityType, model.Vec2Int position) {
+        this.entityType = entityType;
+        this.position = position;
+    }
+    public static BuildAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+        BuildAction result = new BuildAction();
+        switch (StreamUtil.readInt(stream)) {
+        case 0:
+            result.entityType = model.EntityType.WALL;
+            break;
+        case 1:
+            result.entityType = model.EntityType.HOUSE;
+            break;
+        case 2:
+            result.entityType = model.EntityType.BUILDER_BASE;
+            break;
+        case 3:
+            result.entityType = model.EntityType.BUILDER_UNIT;
+            break;
+        case 4:
+            result.entityType = model.EntityType.MELEE_BASE;
+            break;
+        case 5:
+            result.entityType = model.EntityType.MELEE_UNIT;
+            break;
+        case 6:
+            result.entityType = model.EntityType.RANGED_BASE;
+            break;
+        case 7:
+            result.entityType = model.EntityType.RANGED_UNIT;
+            break;
+        case 8:
+            result.entityType = model.EntityType.RESOURCE;
+            break;
+        case 9:
+            result.entityType = model.EntityType.TURRET;
+            break;
+        default:
+            throw new java.io.IOException("Unexpected tag value");
+        }
+        result.position = model.Vec2Int.readFrom(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, entityType.tag);
+        position.writeTo(stream);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/BuildProperties.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/BuildProperties.java
@@ -1,0 +1,75 @@
+package model;
+
+import util.StreamUtil;
+
+public class BuildProperties {
+    private model.EntityType[] options;
+    public model.EntityType[] getOptions() { return options; }
+    public void setOptions(model.EntityType[] options) { this.options = options; }
+    private Integer initHealth;
+    public Integer getInitHealth() { return initHealth; }
+    public void setInitHealth(Integer initHealth) { this.initHealth = initHealth; }
+    public BuildProperties() {}
+    public BuildProperties(model.EntityType[] options, Integer initHealth) {
+        this.options = options;
+        this.initHealth = initHealth;
+    }
+    public static BuildProperties readFrom(java.io.InputStream stream) throws java.io.IOException {
+        BuildProperties result = new BuildProperties();
+        result.options = new model.EntityType[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.options.length; i++) {
+            switch (StreamUtil.readInt(stream)) {
+            case 0:
+                result.options[i] = model.EntityType.WALL;
+                break;
+            case 1:
+                result.options[i] = model.EntityType.HOUSE;
+                break;
+            case 2:
+                result.options[i] = model.EntityType.BUILDER_BASE;
+                break;
+            case 3:
+                result.options[i] = model.EntityType.BUILDER_UNIT;
+                break;
+            case 4:
+                result.options[i] = model.EntityType.MELEE_BASE;
+                break;
+            case 5:
+                result.options[i] = model.EntityType.MELEE_UNIT;
+                break;
+            case 6:
+                result.options[i] = model.EntityType.RANGED_BASE;
+                break;
+            case 7:
+                result.options[i] = model.EntityType.RANGED_UNIT;
+                break;
+            case 8:
+                result.options[i] = model.EntityType.RESOURCE;
+                break;
+            case 9:
+                result.options[i] = model.EntityType.TURRET;
+                break;
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+            }
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.initHealth = StreamUtil.readInt(stream);
+        } else {
+            result.initHealth = null;
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, options.length);
+        for (model.EntityType optionsElement : options) {
+            StreamUtil.writeInt(stream, optionsElement.tag);
+        }
+        if (initHealth == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            StreamUtil.writeInt(stream, initHealth);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Camera.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Camera.java
@@ -1,0 +1,45 @@
+package model;
+
+import util.StreamUtil;
+
+public class Camera {
+    private model.Vec2Float center;
+    public model.Vec2Float getCenter() { return center; }
+    public void setCenter(model.Vec2Float center) { this.center = center; }
+    private float rotation;
+    public float getRotation() { return rotation; }
+    public void setRotation(float rotation) { this.rotation = rotation; }
+    private float attack;
+    public float getAttack() { return attack; }
+    public void setAttack(float attack) { this.attack = attack; }
+    private float distance;
+    public float getDistance() { return distance; }
+    public void setDistance(float distance) { this.distance = distance; }
+    private boolean perspective;
+    public boolean isPerspective() { return perspective; }
+    public void setPerspective(boolean perspective) { this.perspective = perspective; }
+    public Camera() {}
+    public Camera(model.Vec2Float center, float rotation, float attack, float distance, boolean perspective) {
+        this.center = center;
+        this.rotation = rotation;
+        this.attack = attack;
+        this.distance = distance;
+        this.perspective = perspective;
+    }
+    public static Camera readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Camera result = new Camera();
+        result.center = model.Vec2Float.readFrom(stream);
+        result.rotation = StreamUtil.readFloat(stream);
+        result.attack = StreamUtil.readFloat(stream);
+        result.distance = StreamUtil.readFloat(stream);
+        result.perspective = StreamUtil.readBoolean(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        center.writeTo(stream);
+        StreamUtil.writeFloat(stream, rotation);
+        StreamUtil.writeFloat(stream, attack);
+        StreamUtil.writeFloat(stream, distance);
+        StreamUtil.writeBoolean(stream, perspective);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/ClientMessage.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/ClientMessage.java
@@ -1,0 +1,89 @@
+package model;
+
+import util.StreamUtil;
+
+public abstract class ClientMessage {
+    public abstract void writeTo(java.io.OutputStream stream) throws java.io.IOException;
+    public static ClientMessage readFrom(java.io.InputStream stream) throws java.io.IOException {
+        switch (StreamUtil.readInt(stream)) {
+            case DebugMessage.TAG:
+                return DebugMessage.readFrom(stream);
+            case ActionMessage.TAG:
+                return ActionMessage.readFrom(stream);
+            case DebugUpdateDone.TAG:
+                return DebugUpdateDone.readFrom(stream);
+            case RequestDebugState.TAG:
+                return RequestDebugState.readFrom(stream);
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+        }
+    }
+
+    public static class DebugMessage extends ClientMessage {
+        public static final int TAG = 0;
+        private model.DebugCommand command;
+        public model.DebugCommand getCommand() { return command; }
+        public void setCommand(model.DebugCommand command) { this.command = command; }
+        public DebugMessage() {}
+        public DebugMessage(model.DebugCommand command) {
+            this.command = command;
+        }
+        public static DebugMessage readFrom(java.io.InputStream stream) throws java.io.IOException {
+            DebugMessage result = new DebugMessage();
+            result.command = model.DebugCommand.readFrom(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            command.writeTo(stream);
+        }
+    }
+
+    public static class ActionMessage extends ClientMessage {
+        public static final int TAG = 1;
+        private model.Action action;
+        public model.Action getAction() { return action; }
+        public void setAction(model.Action action) { this.action = action; }
+        public ActionMessage() {}
+        public ActionMessage(model.Action action) {
+            this.action = action;
+        }
+        public static ActionMessage readFrom(java.io.InputStream stream) throws java.io.IOException {
+            ActionMessage result = new ActionMessage();
+            result.action = model.Action.readFrom(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            action.writeTo(stream);
+        }
+    }
+
+    public static class DebugUpdateDone extends ClientMessage {
+        public static final int TAG = 2;
+        public DebugUpdateDone() {}
+        public static DebugUpdateDone readFrom(java.io.InputStream stream) throws java.io.IOException {
+            DebugUpdateDone result = new DebugUpdateDone();
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+        }
+    }
+
+    public static class RequestDebugState extends ClientMessage {
+        public static final int TAG = 3;
+        public RequestDebugState() {}
+        public static RequestDebugState readFrom(java.io.InputStream stream) throws java.io.IOException {
+            RequestDebugState result = new RequestDebugState();
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Color.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Color.java
@@ -1,0 +1,39 @@
+package model;
+
+import util.StreamUtil;
+
+public class Color {
+    private float r;
+    public float getR() { return r; }
+    public void setR(float r) { this.r = r; }
+    private float g;
+    public float getG() { return g; }
+    public void setG(float g) { this.g = g; }
+    private float b;
+    public float getB() { return b; }
+    public void setB(float b) { this.b = b; }
+    private float a;
+    public float getA() { return a; }
+    public void setA(float a) { this.a = a; }
+    public Color() {}
+    public Color(float r, float g, float b, float a) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+    public static Color readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Color result = new Color();
+        result.r = StreamUtil.readFloat(stream);
+        result.g = StreamUtil.readFloat(stream);
+        result.b = StreamUtil.readFloat(stream);
+        result.a = StreamUtil.readFloat(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeFloat(stream, r);
+        StreamUtil.writeFloat(stream, g);
+        StreamUtil.writeFloat(stream, b);
+        StreamUtil.writeFloat(stream, a);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/ColoredVertex.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/ColoredVertex.java
@@ -1,0 +1,42 @@
+package model;
+
+import util.StreamUtil;
+
+public class ColoredVertex {
+    private model.Vec2Float worldPos;
+    public model.Vec2Float getWorldPos() { return worldPos; }
+    public void setWorldPos(model.Vec2Float worldPos) { this.worldPos = worldPos; }
+    private model.Vec2Float screenOffset;
+    public model.Vec2Float getScreenOffset() { return screenOffset; }
+    public void setScreenOffset(model.Vec2Float screenOffset) { this.screenOffset = screenOffset; }
+    private model.Color color;
+    public model.Color getColor() { return color; }
+    public void setColor(model.Color color) { this.color = color; }
+    public ColoredVertex() {}
+    public ColoredVertex(model.Vec2Float worldPos, model.Vec2Float screenOffset, model.Color color) {
+        this.worldPos = worldPos;
+        this.screenOffset = screenOffset;
+        this.color = color;
+    }
+    public static ColoredVertex readFrom(java.io.InputStream stream) throws java.io.IOException {
+        ColoredVertex result = new ColoredVertex();
+        if (StreamUtil.readBoolean(stream)) {
+            result.worldPos = model.Vec2Float.readFrom(stream);
+        } else {
+            result.worldPos = null;
+        }
+        result.screenOffset = model.Vec2Float.readFrom(stream);
+        result.color = model.Color.readFrom(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        if (worldPos == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            worldPos.writeTo(stream);
+        }
+        screenOffset.writeTo(stream);
+        color.writeTo(stream);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/DebugCommand.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/DebugCommand.java
@@ -1,0 +1,89 @@
+package model;
+
+import util.StreamUtil;
+
+public abstract class DebugCommand {
+    public abstract void writeTo(java.io.OutputStream stream) throws java.io.IOException;
+    public static DebugCommand readFrom(java.io.InputStream stream) throws java.io.IOException {
+        switch (StreamUtil.readInt(stream)) {
+            case Add.TAG:
+                return Add.readFrom(stream);
+            case Clear.TAG:
+                return Clear.readFrom(stream);
+            case SetAutoFlush.TAG:
+                return SetAutoFlush.readFrom(stream);
+            case Flush.TAG:
+                return Flush.readFrom(stream);
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+        }
+    }
+
+    public static class Add extends DebugCommand {
+        public static final int TAG = 0;
+        private model.DebugData data;
+        public model.DebugData getData() { return data; }
+        public void setData(model.DebugData data) { this.data = data; }
+        public Add() {}
+        public Add(model.DebugData data) {
+            this.data = data;
+        }
+        public static Add readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Add result = new Add();
+            result.data = model.DebugData.readFrom(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            data.writeTo(stream);
+        }
+    }
+
+    public static class Clear extends DebugCommand {
+        public static final int TAG = 1;
+        public Clear() {}
+        public static Clear readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Clear result = new Clear();
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+        }
+    }
+
+    public static class SetAutoFlush extends DebugCommand {
+        public static final int TAG = 2;
+        private boolean enable;
+        public boolean isEnable() { return enable; }
+        public void setEnable(boolean enable) { this.enable = enable; }
+        public SetAutoFlush() {}
+        public SetAutoFlush(boolean enable) {
+            this.enable = enable;
+        }
+        public static SetAutoFlush readFrom(java.io.InputStream stream) throws java.io.IOException {
+            SetAutoFlush result = new SetAutoFlush();
+            result.enable = StreamUtil.readBoolean(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            StreamUtil.writeBoolean(stream, enable);
+        }
+    }
+
+    public static class Flush extends DebugCommand {
+        public static final int TAG = 3;
+        public Flush() {}
+        public static Flush readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Flush result = new Flush();
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/DebugData.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/DebugData.java
@@ -1,0 +1,121 @@
+package model;
+
+import util.StreamUtil;
+
+public abstract class DebugData {
+    public abstract void writeTo(java.io.OutputStream stream) throws java.io.IOException;
+    public static DebugData readFrom(java.io.InputStream stream) throws java.io.IOException {
+        switch (StreamUtil.readInt(stream)) {
+            case Log.TAG:
+                return Log.readFrom(stream);
+            case Primitives.TAG:
+                return Primitives.readFrom(stream);
+            case PlacedText.TAG:
+                return PlacedText.readFrom(stream);
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+        }
+    }
+
+    public static class Log extends DebugData {
+        public static final int TAG = 0;
+        private String text;
+        public String getText() { return text; }
+        public void setText(String text) { this.text = text; }
+        public Log() {}
+        public Log(String text) {
+            this.text = text;
+        }
+        public static Log readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Log result = new Log();
+            result.text = StreamUtil.readString(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            StreamUtil.writeString(stream, text);
+        }
+    }
+
+    public static class Primitives extends DebugData {
+        public static final int TAG = 1;
+        private model.ColoredVertex[] vertices;
+        public model.ColoredVertex[] getVertices() { return vertices; }
+        public void setVertices(model.ColoredVertex[] vertices) { this.vertices = vertices; }
+        private model.PrimitiveType primitiveType;
+        public model.PrimitiveType getPrimitiveType() { return primitiveType; }
+        public void setPrimitiveType(model.PrimitiveType primitiveType) { this.primitiveType = primitiveType; }
+        public Primitives() {}
+        public Primitives(model.ColoredVertex[] vertices, model.PrimitiveType primitiveType) {
+            this.vertices = vertices;
+            this.primitiveType = primitiveType;
+        }
+        public static Primitives readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Primitives result = new Primitives();
+            result.vertices = new model.ColoredVertex[StreamUtil.readInt(stream)];
+            for (int i = 0; i < result.vertices.length; i++) {
+                result.vertices[i] = model.ColoredVertex.readFrom(stream);
+            }
+            switch (StreamUtil.readInt(stream)) {
+            case 0:
+                result.primitiveType = model.PrimitiveType.LINES;
+                break;
+            case 1:
+                result.primitiveType = model.PrimitiveType.TRIANGLES;
+                break;
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+            }
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            StreamUtil.writeInt(stream, vertices.length);
+            for (model.ColoredVertex verticesElement : vertices) {
+                verticesElement.writeTo(stream);
+            }
+            StreamUtil.writeInt(stream, primitiveType.tag);
+        }
+    }
+
+    public static class PlacedText extends DebugData {
+        public static final int TAG = 2;
+        private model.ColoredVertex vertex;
+        public model.ColoredVertex getVertex() { return vertex; }
+        public void setVertex(model.ColoredVertex vertex) { this.vertex = vertex; }
+        private String text;
+        public String getText() { return text; }
+        public void setText(String text) { this.text = text; }
+        private float alignment;
+        public float getAlignment() { return alignment; }
+        public void setAlignment(float alignment) { this.alignment = alignment; }
+        private float size;
+        public float getSize() { return size; }
+        public void setSize(float size) { this.size = size; }
+        public PlacedText() {}
+        public PlacedText(model.ColoredVertex vertex, String text, float alignment, float size) {
+            this.vertex = vertex;
+            this.text = text;
+            this.alignment = alignment;
+            this.size = size;
+        }
+        public static PlacedText readFrom(java.io.InputStream stream) throws java.io.IOException {
+            PlacedText result = new PlacedText();
+            result.vertex = model.ColoredVertex.readFrom(stream);
+            result.text = StreamUtil.readString(stream);
+            result.alignment = StreamUtil.readFloat(stream);
+            result.size = StreamUtil.readFloat(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            vertex.writeTo(stream);
+            StreamUtil.writeString(stream, text);
+            StreamUtil.writeFloat(stream, alignment);
+            StreamUtil.writeFloat(stream, size);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/DebugState.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/DebugState.java
@@ -1,0 +1,57 @@
+package model;
+
+import util.StreamUtil;
+
+public class DebugState {
+    private model.Vec2Int windowSize;
+    public model.Vec2Int getWindowSize() { return windowSize; }
+    public void setWindowSize(model.Vec2Int windowSize) { this.windowSize = windowSize; }
+    private model.Vec2Float mousePosWindow;
+    public model.Vec2Float getMousePosWindow() { return mousePosWindow; }
+    public void setMousePosWindow(model.Vec2Float mousePosWindow) { this.mousePosWindow = mousePosWindow; }
+    private model.Vec2Float mousePosWorld;
+    public model.Vec2Float getMousePosWorld() { return mousePosWorld; }
+    public void setMousePosWorld(model.Vec2Float mousePosWorld) { this.mousePosWorld = mousePosWorld; }
+    private String[] pressedKeys;
+    public String[] getPressedKeys() { return pressedKeys; }
+    public void setPressedKeys(String[] pressedKeys) { this.pressedKeys = pressedKeys; }
+    private model.Camera camera;
+    public model.Camera getCamera() { return camera; }
+    public void setCamera(model.Camera camera) { this.camera = camera; }
+    private int playerIndex;
+    public int getPlayerIndex() { return playerIndex; }
+    public void setPlayerIndex(int playerIndex) { this.playerIndex = playerIndex; }
+    public DebugState() {}
+    public DebugState(model.Vec2Int windowSize, model.Vec2Float mousePosWindow, model.Vec2Float mousePosWorld, String[] pressedKeys, model.Camera camera, int playerIndex) {
+        this.windowSize = windowSize;
+        this.mousePosWindow = mousePosWindow;
+        this.mousePosWorld = mousePosWorld;
+        this.pressedKeys = pressedKeys;
+        this.camera = camera;
+        this.playerIndex = playerIndex;
+    }
+    public static DebugState readFrom(java.io.InputStream stream) throws java.io.IOException {
+        DebugState result = new DebugState();
+        result.windowSize = model.Vec2Int.readFrom(stream);
+        result.mousePosWindow = model.Vec2Float.readFrom(stream);
+        result.mousePosWorld = model.Vec2Float.readFrom(stream);
+        result.pressedKeys = new String[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.pressedKeys.length; i++) {
+            result.pressedKeys[i] = StreamUtil.readString(stream);
+        }
+        result.camera = model.Camera.readFrom(stream);
+        result.playerIndex = StreamUtil.readInt(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        windowSize.writeTo(stream);
+        mousePosWindow.writeTo(stream);
+        mousePosWorld.writeTo(stream);
+        StreamUtil.writeInt(stream, pressedKeys.length);
+        for (String pressedKeysElement : pressedKeys) {
+            StreamUtil.writeString(stream, pressedKeysElement);
+        }
+        camera.writeTo(stream);
+        StreamUtil.writeInt(stream, playerIndex);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Entity.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Entity.java
@@ -1,0 +1,93 @@
+package model;
+
+import util.StreamUtil;
+
+public class Entity {
+    private int id;
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+    private Integer playerId;
+    public Integer getPlayerId() { return playerId; }
+    public void setPlayerId(Integer playerId) { this.playerId = playerId; }
+    private model.EntityType entityType;
+    public model.EntityType getEntityType() { return entityType; }
+    public void setEntityType(model.EntityType entityType) { this.entityType = entityType; }
+    private model.Vec2Int position;
+    public model.Vec2Int getPosition() { return position; }
+    public void setPosition(model.Vec2Int position) { this.position = position; }
+    private int health;
+    public int getHealth() { return health; }
+    public void setHealth(int health) { this.health = health; }
+    private boolean active;
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+    public Entity() {}
+    public Entity(int id, Integer playerId, model.EntityType entityType, model.Vec2Int position, int health, boolean active) {
+        this.id = id;
+        this.playerId = playerId;
+        this.entityType = entityType;
+        this.position = position;
+        this.health = health;
+        this.active = active;
+    }
+    public static Entity readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Entity result = new Entity();
+        result.id = StreamUtil.readInt(stream);
+        if (StreamUtil.readBoolean(stream)) {
+            result.playerId = StreamUtil.readInt(stream);
+        } else {
+            result.playerId = null;
+        }
+        switch (StreamUtil.readInt(stream)) {
+        case 0:
+            result.entityType = model.EntityType.WALL;
+            break;
+        case 1:
+            result.entityType = model.EntityType.HOUSE;
+            break;
+        case 2:
+            result.entityType = model.EntityType.BUILDER_BASE;
+            break;
+        case 3:
+            result.entityType = model.EntityType.BUILDER_UNIT;
+            break;
+        case 4:
+            result.entityType = model.EntityType.MELEE_BASE;
+            break;
+        case 5:
+            result.entityType = model.EntityType.MELEE_UNIT;
+            break;
+        case 6:
+            result.entityType = model.EntityType.RANGED_BASE;
+            break;
+        case 7:
+            result.entityType = model.EntityType.RANGED_UNIT;
+            break;
+        case 8:
+            result.entityType = model.EntityType.RESOURCE;
+            break;
+        case 9:
+            result.entityType = model.EntityType.TURRET;
+            break;
+        default:
+            throw new java.io.IOException("Unexpected tag value");
+        }
+        result.position = model.Vec2Int.readFrom(stream);
+        result.health = StreamUtil.readInt(stream);
+        result.active = StreamUtil.readBoolean(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, id);
+        if (playerId == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            StreamUtil.writeInt(stream, playerId);
+        }
+        StreamUtil.writeInt(stream, entityType.tag);
+        position.writeTo(stream);
+        StreamUtil.writeInt(stream, health);
+        StreamUtil.writeBoolean(stream, active);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/EntityAction.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/EntityAction.java
@@ -1,0 +1,75 @@
+package model;
+
+import util.StreamUtil;
+
+public class EntityAction {
+    private model.MoveAction moveAction;
+    public model.MoveAction getMoveAction() { return moveAction; }
+    public void setMoveAction(model.MoveAction moveAction) { this.moveAction = moveAction; }
+    private model.BuildAction buildAction;
+    public model.BuildAction getBuildAction() { return buildAction; }
+    public void setBuildAction(model.BuildAction buildAction) { this.buildAction = buildAction; }
+    private model.AttackAction attackAction;
+    public model.AttackAction getAttackAction() { return attackAction; }
+    public void setAttackAction(model.AttackAction attackAction) { this.attackAction = attackAction; }
+    private model.RepairAction repairAction;
+    public model.RepairAction getRepairAction() { return repairAction; }
+    public void setRepairAction(model.RepairAction repairAction) { this.repairAction = repairAction; }
+    public EntityAction() {}
+    public EntityAction(model.MoveAction moveAction, model.BuildAction buildAction, model.AttackAction attackAction, model.RepairAction repairAction) {
+        this.moveAction = moveAction;
+        this.buildAction = buildAction;
+        this.attackAction = attackAction;
+        this.repairAction = repairAction;
+    }
+    public static EntityAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+        EntityAction result = new EntityAction();
+        if (StreamUtil.readBoolean(stream)) {
+            result.moveAction = model.MoveAction.readFrom(stream);
+        } else {
+            result.moveAction = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.buildAction = model.BuildAction.readFrom(stream);
+        } else {
+            result.buildAction = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.attackAction = model.AttackAction.readFrom(stream);
+        } else {
+            result.attackAction = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.repairAction = model.RepairAction.readFrom(stream);
+        } else {
+            result.repairAction = null;
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        if (moveAction == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            moveAction.writeTo(stream);
+        }
+        if (buildAction == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            buildAction.writeTo(stream);
+        }
+        if (attackAction == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            attackAction.writeTo(stream);
+        }
+        if (repairAction == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            repairAction.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/EntityProperties.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/EntityProperties.java
@@ -1,0 +1,120 @@
+package model;
+
+import util.StreamUtil;
+
+public class EntityProperties {
+    private int size;
+    public int getSize() { return size; }
+    public void setSize(int size) { this.size = size; }
+    private int buildScore;
+    public int getBuildScore() { return buildScore; }
+    public void setBuildScore(int buildScore) { this.buildScore = buildScore; }
+    private int destroyScore;
+    public int getDestroyScore() { return destroyScore; }
+    public void setDestroyScore(int destroyScore) { this.destroyScore = destroyScore; }
+    private boolean canMove;
+    public boolean isCanMove() { return canMove; }
+    public void setCanMove(boolean canMove) { this.canMove = canMove; }
+    private int populationProvide;
+    public int getPopulationProvide() { return populationProvide; }
+    public void setPopulationProvide(int populationProvide) { this.populationProvide = populationProvide; }
+    private int populationUse;
+    public int getPopulationUse() { return populationUse; }
+    public void setPopulationUse(int populationUse) { this.populationUse = populationUse; }
+    private int maxHealth;
+    public int getMaxHealth() { return maxHealth; }
+    public void setMaxHealth(int maxHealth) { this.maxHealth = maxHealth; }
+    private int initialCost;
+    public int getInitialCost() { return initialCost; }
+    public void setInitialCost(int initialCost) { this.initialCost = initialCost; }
+    private int sightRange;
+    public int getSightRange() { return sightRange; }
+    public void setSightRange(int sightRange) { this.sightRange = sightRange; }
+    private int resourcePerHealth;
+    public int getResourcePerHealth() { return resourcePerHealth; }
+    public void setResourcePerHealth(int resourcePerHealth) { this.resourcePerHealth = resourcePerHealth; }
+    private model.BuildProperties build;
+    public model.BuildProperties getBuild() { return build; }
+    public void setBuild(model.BuildProperties build) { this.build = build; }
+    private model.AttackProperties attack;
+    public model.AttackProperties getAttack() { return attack; }
+    public void setAttack(model.AttackProperties attack) { this.attack = attack; }
+    private model.RepairProperties repair;
+    public model.RepairProperties getRepair() { return repair; }
+    public void setRepair(model.RepairProperties repair) { this.repair = repair; }
+    public EntityProperties() {}
+    public EntityProperties(int size, int buildScore, int destroyScore, boolean canMove, int populationProvide, int populationUse, int maxHealth, int initialCost, int sightRange, int resourcePerHealth, model.BuildProperties build, model.AttackProperties attack, model.RepairProperties repair) {
+        this.size = size;
+        this.buildScore = buildScore;
+        this.destroyScore = destroyScore;
+        this.canMove = canMove;
+        this.populationProvide = populationProvide;
+        this.populationUse = populationUse;
+        this.maxHealth = maxHealth;
+        this.initialCost = initialCost;
+        this.sightRange = sightRange;
+        this.resourcePerHealth = resourcePerHealth;
+        this.build = build;
+        this.attack = attack;
+        this.repair = repair;
+    }
+    public static EntityProperties readFrom(java.io.InputStream stream) throws java.io.IOException {
+        EntityProperties result = new EntityProperties();
+        result.size = StreamUtil.readInt(stream);
+        result.buildScore = StreamUtil.readInt(stream);
+        result.destroyScore = StreamUtil.readInt(stream);
+        result.canMove = StreamUtil.readBoolean(stream);
+        result.populationProvide = StreamUtil.readInt(stream);
+        result.populationUse = StreamUtil.readInt(stream);
+        result.maxHealth = StreamUtil.readInt(stream);
+        result.initialCost = StreamUtil.readInt(stream);
+        result.sightRange = StreamUtil.readInt(stream);
+        result.resourcePerHealth = StreamUtil.readInt(stream);
+        if (StreamUtil.readBoolean(stream)) {
+            result.build = model.BuildProperties.readFrom(stream);
+        } else {
+            result.build = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.attack = model.AttackProperties.readFrom(stream);
+        } else {
+            result.attack = null;
+        }
+        if (StreamUtil.readBoolean(stream)) {
+            result.repair = model.RepairProperties.readFrom(stream);
+        } else {
+            result.repair = null;
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, size);
+        StreamUtil.writeInt(stream, buildScore);
+        StreamUtil.writeInt(stream, destroyScore);
+        StreamUtil.writeBoolean(stream, canMove);
+        StreamUtil.writeInt(stream, populationProvide);
+        StreamUtil.writeInt(stream, populationUse);
+        StreamUtil.writeInt(stream, maxHealth);
+        StreamUtil.writeInt(stream, initialCost);
+        StreamUtil.writeInt(stream, sightRange);
+        StreamUtil.writeInt(stream, resourcePerHealth);
+        if (build == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            build.writeTo(stream);
+        }
+        if (attack == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            attack.writeTo(stream);
+        }
+        if (repair == null) {
+            StreamUtil.writeBoolean(stream, false);
+        } else {
+            StreamUtil.writeBoolean(stream, true);
+            repair.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/EntityType.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/EntityType.java
@@ -1,0 +1,20 @@
+package model;
+
+import util.StreamUtil;
+
+public enum EntityType {
+    WALL(0),
+    HOUSE(1),
+    BUILDER_BASE(2),
+    BUILDER_UNIT(3),
+    MELEE_BASE(4),
+    MELEE_UNIT(5),
+    RANGED_BASE(6),
+    RANGED_UNIT(7),
+    RESOURCE(8),
+    TURRET(9);
+    public int tag;
+    EntityType(int tag) {
+      this.tag = tag;
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/MoveAction.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/MoveAction.java
@@ -1,0 +1,33 @@
+package model;
+
+import util.StreamUtil;
+
+public class MoveAction {
+    private model.Vec2Int target;
+    public model.Vec2Int getTarget() { return target; }
+    public void setTarget(model.Vec2Int target) { this.target = target; }
+    private boolean findClosestPosition;
+    public boolean isFindClosestPosition() { return findClosestPosition; }
+    public void setFindClosestPosition(boolean findClosestPosition) { this.findClosestPosition = findClosestPosition; }
+    private boolean breakThrough;
+    public boolean isBreakThrough() { return breakThrough; }
+    public void setBreakThrough(boolean breakThrough) { this.breakThrough = breakThrough; }
+    public MoveAction() {}
+    public MoveAction(model.Vec2Int target, boolean findClosestPosition, boolean breakThrough) {
+        this.target = target;
+        this.findClosestPosition = findClosestPosition;
+        this.breakThrough = breakThrough;
+    }
+    public static MoveAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+        MoveAction result = new MoveAction();
+        result.target = model.Vec2Int.readFrom(stream);
+        result.findClosestPosition = StreamUtil.readBoolean(stream);
+        result.breakThrough = StreamUtil.readBoolean(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        target.writeTo(stream);
+        StreamUtil.writeBoolean(stream, findClosestPosition);
+        StreamUtil.writeBoolean(stream, breakThrough);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Player.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Player.java
@@ -1,0 +1,33 @@
+package model;
+
+import util.StreamUtil;
+
+public class Player {
+    private int id;
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+    private int score;
+    public int getScore() { return score; }
+    public void setScore(int score) { this.score = score; }
+    private int resource;
+    public int getResource() { return resource; }
+    public void setResource(int resource) { this.resource = resource; }
+    public Player() {}
+    public Player(int id, int score, int resource) {
+        this.id = id;
+        this.score = score;
+        this.resource = resource;
+    }
+    public static Player readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Player result = new Player();
+        result.id = StreamUtil.readInt(stream);
+        result.score = StreamUtil.readInt(stream);
+        result.resource = StreamUtil.readInt(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, id);
+        StreamUtil.writeInt(stream, score);
+        StreamUtil.writeInt(stream, resource);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/PlayerView.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/PlayerView.java
@@ -1,0 +1,128 @@
+package model;
+
+import util.StreamUtil;
+
+public class PlayerView {
+    private int myId;
+    public int getMyId() { return myId; }
+    public void setMyId(int myId) { this.myId = myId; }
+    private int mapSize;
+    public int getMapSize() { return mapSize; }
+    public void setMapSize(int mapSize) { this.mapSize = mapSize; }
+    private boolean fogOfWar;
+    public boolean isFogOfWar() { return fogOfWar; }
+    public void setFogOfWar(boolean fogOfWar) { this.fogOfWar = fogOfWar; }
+    private java.util.Map<model.EntityType, model.EntityProperties> entityProperties;
+    public java.util.Map<model.EntityType, model.EntityProperties> getEntityProperties() { return entityProperties; }
+    public void setEntityProperties(java.util.Map<model.EntityType, model.EntityProperties> entityProperties) { this.entityProperties = entityProperties; }
+    private int maxTickCount;
+    public int getMaxTickCount() { return maxTickCount; }
+    public void setMaxTickCount(int maxTickCount) { this.maxTickCount = maxTickCount; }
+    private int maxPathfindNodes;
+    public int getMaxPathfindNodes() { return maxPathfindNodes; }
+    public void setMaxPathfindNodes(int maxPathfindNodes) { this.maxPathfindNodes = maxPathfindNodes; }
+    private int currentTick;
+    public int getCurrentTick() { return currentTick; }
+    public void setCurrentTick(int currentTick) { this.currentTick = currentTick; }
+    private model.Player[] players;
+    public model.Player[] getPlayers() { return players; }
+    public void setPlayers(model.Player[] players) { this.players = players; }
+    private model.Entity[] entities;
+    public model.Entity[] getEntities() { return entities; }
+    public void setEntities(model.Entity[] entities) { this.entities = entities; }
+    public PlayerView() {}
+    public PlayerView(int myId, int mapSize, boolean fogOfWar, java.util.Map<model.EntityType, model.EntityProperties> entityProperties, int maxTickCount, int maxPathfindNodes, int currentTick, model.Player[] players, model.Entity[] entities) {
+        this.myId = myId;
+        this.mapSize = mapSize;
+        this.fogOfWar = fogOfWar;
+        this.entityProperties = entityProperties;
+        this.maxTickCount = maxTickCount;
+        this.maxPathfindNodes = maxPathfindNodes;
+        this.currentTick = currentTick;
+        this.players = players;
+        this.entities = entities;
+    }
+    public static PlayerView readFrom(java.io.InputStream stream) throws java.io.IOException {
+        PlayerView result = new PlayerView();
+        result.myId = StreamUtil.readInt(stream);
+        result.mapSize = StreamUtil.readInt(stream);
+        result.fogOfWar = StreamUtil.readBoolean(stream);
+        int entityPropertiesSize = StreamUtil.readInt(stream);
+        result.entityProperties = new java.util.HashMap<>(entityPropertiesSize);
+        for (int i = 0; i < entityPropertiesSize; i++) {
+            model.EntityType entityPropertiesKey;
+            switch (StreamUtil.readInt(stream)) {
+            case 0:
+                entityPropertiesKey = model.EntityType.WALL;
+                break;
+            case 1:
+                entityPropertiesKey = model.EntityType.HOUSE;
+                break;
+            case 2:
+                entityPropertiesKey = model.EntityType.BUILDER_BASE;
+                break;
+            case 3:
+                entityPropertiesKey = model.EntityType.BUILDER_UNIT;
+                break;
+            case 4:
+                entityPropertiesKey = model.EntityType.MELEE_BASE;
+                break;
+            case 5:
+                entityPropertiesKey = model.EntityType.MELEE_UNIT;
+                break;
+            case 6:
+                entityPropertiesKey = model.EntityType.RANGED_BASE;
+                break;
+            case 7:
+                entityPropertiesKey = model.EntityType.RANGED_UNIT;
+                break;
+            case 8:
+                entityPropertiesKey = model.EntityType.RESOURCE;
+                break;
+            case 9:
+                entityPropertiesKey = model.EntityType.TURRET;
+                break;
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+            }
+            model.EntityProperties entityPropertiesValue;
+            entityPropertiesValue = model.EntityProperties.readFrom(stream);
+            result.entityProperties.put(entityPropertiesKey, entityPropertiesValue);
+        }
+        result.maxTickCount = StreamUtil.readInt(stream);
+        result.maxPathfindNodes = StreamUtil.readInt(stream);
+        result.currentTick = StreamUtil.readInt(stream);
+        result.players = new model.Player[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.players.length; i++) {
+            result.players[i] = model.Player.readFrom(stream);
+        }
+        result.entities = new model.Entity[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.entities.length; i++) {
+            result.entities[i] = model.Entity.readFrom(stream);
+        }
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, myId);
+        StreamUtil.writeInt(stream, mapSize);
+        StreamUtil.writeBoolean(stream, fogOfWar);
+        StreamUtil.writeInt(stream, entityProperties.size());
+        for (java.util.Map.Entry<model.EntityType, model.EntityProperties> entityPropertiesEntry : entityProperties.entrySet()) {
+            model.EntityType entityPropertiesKey = entityPropertiesEntry.getKey();
+            model.EntityProperties entityPropertiesValue = entityPropertiesEntry.getValue();
+            StreamUtil.writeInt(stream, entityPropertiesKey.tag);
+            entityPropertiesValue.writeTo(stream);
+        }
+        StreamUtil.writeInt(stream, maxTickCount);
+        StreamUtil.writeInt(stream, maxPathfindNodes);
+        StreamUtil.writeInt(stream, currentTick);
+        StreamUtil.writeInt(stream, players.length);
+        for (model.Player playersElement : players) {
+            playersElement.writeTo(stream);
+        }
+        StreamUtil.writeInt(stream, entities.length);
+        for (model.Entity entitiesElement : entities) {
+            entitiesElement.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/PrimitiveType.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/PrimitiveType.java
@@ -1,0 +1,12 @@
+package model;
+
+import util.StreamUtil;
+
+public enum PrimitiveType {
+    LINES(0),
+    TRIANGLES(1);
+    public int tag;
+    PrimitiveType(int tag) {
+      this.tag = tag;
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/RepairAction.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/RepairAction.java
@@ -1,0 +1,21 @@
+package model;
+
+import util.StreamUtil;
+
+public class RepairAction {
+    private int target;
+    public int getTarget() { return target; }
+    public void setTarget(int target) { this.target = target; }
+    public RepairAction() {}
+    public RepairAction(int target) {
+        this.target = target;
+    }
+    public static RepairAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+        RepairAction result = new RepairAction();
+        result.target = StreamUtil.readInt(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, target);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/RepairProperties.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/RepairProperties.java
@@ -1,0 +1,66 @@
+package model;
+
+import util.StreamUtil;
+
+public class RepairProperties {
+    private model.EntityType[] validTargets;
+    public model.EntityType[] getValidTargets() { return validTargets; }
+    public void setValidTargets(model.EntityType[] validTargets) { this.validTargets = validTargets; }
+    private int power;
+    public int getPower() { return power; }
+    public void setPower(int power) { this.power = power; }
+    public RepairProperties() {}
+    public RepairProperties(model.EntityType[] validTargets, int power) {
+        this.validTargets = validTargets;
+        this.power = power;
+    }
+    public static RepairProperties readFrom(java.io.InputStream stream) throws java.io.IOException {
+        RepairProperties result = new RepairProperties();
+        result.validTargets = new model.EntityType[StreamUtil.readInt(stream)];
+        for (int i = 0; i < result.validTargets.length; i++) {
+            switch (StreamUtil.readInt(stream)) {
+            case 0:
+                result.validTargets[i] = model.EntityType.WALL;
+                break;
+            case 1:
+                result.validTargets[i] = model.EntityType.HOUSE;
+                break;
+            case 2:
+                result.validTargets[i] = model.EntityType.BUILDER_BASE;
+                break;
+            case 3:
+                result.validTargets[i] = model.EntityType.BUILDER_UNIT;
+                break;
+            case 4:
+                result.validTargets[i] = model.EntityType.MELEE_BASE;
+                break;
+            case 5:
+                result.validTargets[i] = model.EntityType.MELEE_UNIT;
+                break;
+            case 6:
+                result.validTargets[i] = model.EntityType.RANGED_BASE;
+                break;
+            case 7:
+                result.validTargets[i] = model.EntityType.RANGED_UNIT;
+                break;
+            case 8:
+                result.validTargets[i] = model.EntityType.RESOURCE;
+                break;
+            case 9:
+                result.validTargets[i] = model.EntityType.TURRET;
+                break;
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+            }
+        }
+        result.power = StreamUtil.readInt(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, validTargets.length);
+        for (model.EntityType validTargetsElement : validTargets) {
+            StreamUtil.writeInt(stream, validTargetsElement.tag);
+        }
+        StreamUtil.writeInt(stream, power);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/ServerMessage.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/ServerMessage.java
@@ -1,0 +1,80 @@
+package model;
+
+import util.StreamUtil;
+
+public abstract class ServerMessage {
+    public abstract void writeTo(java.io.OutputStream stream) throws java.io.IOException;
+    public static ServerMessage readFrom(java.io.InputStream stream) throws java.io.IOException {
+        switch (StreamUtil.readInt(stream)) {
+            case GetAction.TAG:
+                return GetAction.readFrom(stream);
+            case Finish.TAG:
+                return Finish.readFrom(stream);
+            case DebugUpdate.TAG:
+                return DebugUpdate.readFrom(stream);
+            default:
+                throw new java.io.IOException("Unexpected tag value");
+        }
+    }
+
+    public static class GetAction extends ServerMessage {
+        public static final int TAG = 0;
+        private model.PlayerView playerView;
+        public model.PlayerView getPlayerView() { return playerView; }
+        public void setPlayerView(model.PlayerView playerView) { this.playerView = playerView; }
+        private boolean debugAvailable;
+        public boolean isDebugAvailable() { return debugAvailable; }
+        public void setDebugAvailable(boolean debugAvailable) { this.debugAvailable = debugAvailable; }
+        public GetAction() {}
+        public GetAction(model.PlayerView playerView, boolean debugAvailable) {
+            this.playerView = playerView;
+            this.debugAvailable = debugAvailable;
+        }
+        public static GetAction readFrom(java.io.InputStream stream) throws java.io.IOException {
+            GetAction result = new GetAction();
+            result.playerView = model.PlayerView.readFrom(stream);
+            result.debugAvailable = StreamUtil.readBoolean(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            playerView.writeTo(stream);
+            StreamUtil.writeBoolean(stream, debugAvailable);
+        }
+    }
+
+    public static class Finish extends ServerMessage {
+        public static final int TAG = 1;
+        public Finish() {}
+        public static Finish readFrom(java.io.InputStream stream) throws java.io.IOException {
+            Finish result = new Finish();
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+        }
+    }
+
+    public static class DebugUpdate extends ServerMessage {
+        public static final int TAG = 2;
+        private model.PlayerView playerView;
+        public model.PlayerView getPlayerView() { return playerView; }
+        public void setPlayerView(model.PlayerView playerView) { this.playerView = playerView; }
+        public DebugUpdate() {}
+        public DebugUpdate(model.PlayerView playerView) {
+            this.playerView = playerView;
+        }
+        public static DebugUpdate readFrom(java.io.InputStream stream) throws java.io.IOException {
+            DebugUpdate result = new DebugUpdate();
+            result.playerView = model.PlayerView.readFrom(stream);
+            return result;
+        }
+        @Override
+        public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+            StreamUtil.writeInt(stream, TAG);
+            playerView.writeTo(stream);
+        }
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Vec2Float.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Vec2Float.java
@@ -1,0 +1,27 @@
+package model;
+
+import util.StreamUtil;
+
+public class Vec2Float {
+    private float x;
+    public float getX() { return x; }
+    public void setX(float x) { this.x = x; }
+    private float y;
+    public float getY() { return y; }
+    public void setY(float y) { this.y = y; }
+    public Vec2Float() {}
+    public Vec2Float(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+    public static Vec2Float readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Vec2Float result = new Vec2Float();
+        result.x = StreamUtil.readFloat(stream);
+        result.y = StreamUtil.readFloat(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeFloat(stream, x);
+        StreamUtil.writeFloat(stream, y);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/model/Vec2Int.java
+++ b/clients/Java-GraalVM-native/src/main/java/model/Vec2Int.java
@@ -1,0 +1,27 @@
+package model;
+
+import util.StreamUtil;
+
+public class Vec2Int {
+    private int x;
+    public int getX() { return x; }
+    public void setX(int x) { this.x = x; }
+    private int y;
+    public int getY() { return y; }
+    public void setY(int y) { this.y = y; }
+    public Vec2Int() {}
+    public Vec2Int(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+    public static Vec2Int readFrom(java.io.InputStream stream) throws java.io.IOException {
+        Vec2Int result = new Vec2Int();
+        result.x = StreamUtil.readInt(stream);
+        result.y = StreamUtil.readInt(stream);
+        return result;
+    }
+    public void writeTo(java.io.OutputStream stream) throws java.io.IOException {
+        StreamUtil.writeInt(stream, x);
+        StreamUtil.writeInt(stream, y);
+    }
+}

--- a/clients/Java-GraalVM-native/src/main/java/util/StreamUtil.java
+++ b/clients/Java-GraalVM-native/src/main/java/util/StreamUtil.java
@@ -1,0 +1,82 @@
+package util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class StreamUtil {
+    public static byte[] readBytes(InputStream stream, int byteCount) throws IOException {
+        byte[] bytes = new byte[byteCount];
+        int offset = 0;
+        while (offset < bytes.length) {
+            int read = stream.read(bytes, offset, bytes.length - offset);
+            if (read == -1) {
+                break;
+            }
+            offset += read;
+        }
+        if (offset != bytes.length) {
+            throw new IOException("Unexpected EOF");
+        }
+        return bytes;
+    }
+
+    public static boolean readBoolean(InputStream stream) throws IOException {
+        return ByteBuffer.wrap(readBytes(stream, 1)).get() != 0;
+    }
+
+    public static int readInt(InputStream stream) throws IOException {
+        return ByteBuffer.wrap(readBytes(stream, Integer.BYTES)).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+
+    public static long readLong(InputStream stream) throws IOException {
+        return ByteBuffer.wrap(readBytes(stream, Long.BYTES)).order(ByteOrder.LITTLE_ENDIAN).getLong();
+    }
+
+    public static float readFloat(InputStream stream) throws IOException {
+        return ByteBuffer.wrap(readBytes(stream, Float.BYTES)).order(ByteOrder.LITTLE_ENDIAN).getFloat();
+    }
+
+    public static double readDouble(InputStream stream) throws IOException {
+        return ByteBuffer.wrap(readBytes(stream, Double.BYTES)).order(ByteOrder.LITTLE_ENDIAN).getDouble();
+    }
+
+    public static String readString(InputStream stream) throws IOException {
+        int length = readInt(stream);
+        return new String(readBytes(stream, length), StandardCharsets.UTF_8);
+    }
+
+    public static void writeBytes(OutputStream stream, byte[] bytes) throws IOException {
+        stream.write(bytes);
+    }
+
+    public static void writeBoolean(OutputStream stream, boolean value) throws IOException {
+        writeBytes(stream, new byte[] { (byte) (value ? 1 : 0) });
+    }
+
+    public static void writeInt(OutputStream stream, int value) throws IOException {
+        writeBytes(stream, ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array());
+    }
+
+    public static void writeLong(OutputStream stream, long value) throws IOException {
+        writeBytes(stream, ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array());
+    }
+
+    public static void writeFloat(OutputStream stream, float value) throws IOException {
+        writeBytes(stream, ByteBuffer.allocate(Float.BYTES).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array());
+    }
+
+    public static void writeDouble(OutputStream stream, double value) throws IOException {
+        writeBytes(stream, ByteBuffer.allocate(Double.BYTES).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array());
+    }
+
+    public static void writeString(OutputStream stream, String value) throws IOException {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        writeInt(stream, bytes.length);
+        writeBytes(stream, bytes);
+    }
+}

--- a/clients/Kotlin-GraalVM-native/Dockerfile
+++ b/clients/Kotlin-GraalVM-native/Dockerfile
@@ -1,0 +1,20 @@
+FROM oracle/graalvm-ce:20.2.0-java11 AS build-aot
+
+
+RUN gu install native-image
+RUN yum install wget -y
+RUN wget https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /tmp
+RUN tar xf /tmp/apache-maven-3.6.3-bin.tar.gz -C /opt
+RUN ln -s /opt/apache-maven-3.6.3 /opt/maven
+RUN ln -s /opt/graalvm-ce-java11-20.2.0 /opt/graalvm
+
+ENV JAVA_HOME=/opt/graalvm
+ENV M2_HOME=/opt/maven
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${M2_HOME}/bin:${PATH}
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+COPY . /project
+WORKDIR /project
+
+RUN mvn package --batch-mode

--- a/clients/Kotlin-GraalVM-native/compile.sh
+++ b/clients/Kotlin-GraalVM-native/compile.sh
@@ -1,0 +1,13 @@
+set -ex
+
+if [ "$1" != "base" ]; then
+    if [[ `ls -1 /src/ | wc -l` -eq 1 ]]; then
+        cp -f /src/MyStrategy.kt src/main/kotlin/MyStrategy.kt
+    else
+        rm -rf ./*
+        cp -rf /src/* ./
+    fi
+fi
+
+mvn package --batch-mode
+cp target/aicup2020-native-with-dependencies /output/

--- a/clients/Kotlin-GraalVM-native/pom.xml
+++ b/clients/Kotlin-GraalVM-native/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.codegame.aicup2020.devkit</groupId>
+    <artifactId>aicup2020</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>aicup2020</name>
+
+    <properties>
+        <kotlin.version>1.4.20</kotlin.version>
+        <graalvm.version>20.2.0</graalvm.version>
+        <main.class>Runner</main.class>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>${graalvm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>aicup2020</finalName>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.nativeimage</groupId>
+                <artifactId>native-image-maven-plugin</artifactId>
+                <version>${graalvm.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>native-image</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>false</skip>
+                    <imageName>aicup2020-native-with-dependencies</imageName>
+                    <buildArgs>
+            --no-fallback
+                    </buildArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+
+                <configuration />
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>Runner</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/clients/Kotlin-GraalVM-native/run.sh
+++ b/clients/Kotlin-GraalVM-native/run.sh
@@ -1,0 +1,4 @@
+set -ex
+
+cd /output
+./aicup2020-native-with-dependencies "$@"

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/DebugInterface.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/DebugInterface.kt
@@ -1,0 +1,23 @@
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+class DebugInterface(private val inputStream: InputStream, private val outputStream: OutputStream) {
+    fun send(command: model.DebugCommand) {
+        try {
+            model.ClientMessage.DebugMessage(command).writeTo(outputStream)
+            outputStream.flush()
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        }
+    }
+    fun getState(): model.DebugState {
+        try {
+            model.ClientMessage.RequestDebugState().writeTo(outputStream)
+            outputStream.flush()
+            return model.DebugState.readFrom(inputStream)
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/MyStrategy.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/MyStrategy.kt
@@ -1,0 +1,11 @@
+import model.*
+
+class MyStrategy {
+    fun getAction(playerView: PlayerView, debugInterface: DebugInterface?): Action {
+        return Action(mutableMapOf())
+    }
+    fun debugUpdate(playerView: PlayerView, debugInterface: DebugInterface) {
+        debugInterface.send(model.DebugCommand.Clear())
+        debugInterface.getState()
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/Runner.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/Runner.kt
@@ -1,0 +1,53 @@
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import util.StreamUtil
+
+class Runner @Throws(IOException::class)
+internal constructor(host: String, port: Int, token: String) {
+    private val inputStream: InputStream
+    private val outputStream: OutputStream
+
+    init {
+        val socket = Socket(host, port)
+        socket.tcpNoDelay = true
+        inputStream = BufferedInputStream(socket.getInputStream())
+        outputStream = BufferedOutputStream(socket.getOutputStream())
+        StreamUtil.writeString(outputStream, token)
+        outputStream.flush()
+    }
+
+    @Throws(IOException::class)
+    internal fun run() {
+        val myStrategy = MyStrategy()
+        val debugInterface = DebugInterface(inputStream, outputStream)
+        while (true) {
+            val message = model.ServerMessage.readFrom(inputStream)
+            if (message is model.ServerMessage.GetAction) {
+                model.ClientMessage.ActionMessage(myStrategy.getAction(message.playerView, if (message.debugAvailable) debugInterface else null)).writeTo(outputStream)
+                outputStream.flush()
+            } else if (message is model.ServerMessage.Finish) {
+                break
+            } else if (message is model.ServerMessage.DebugUpdate) {
+                myStrategy.debugUpdate(message.playerView, debugInterface)
+                model.ClientMessage.DebugUpdateDone().writeTo(outputStream)
+                outputStream.flush()
+            }
+        }
+    }
+
+    companion object {
+
+        @Throws(IOException::class)
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val host = if (args.size < 1) "127.0.0.1" else args[0]
+            val port = if (args.size < 2) 31001 else Integer.parseInt(args[1])
+            val token = if (args.size < 3) "0000000000000000" else args[2]
+            Runner(host, port, token).run()
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Action.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Action.kt
@@ -1,0 +1,35 @@
+package model
+
+import util.StreamUtil
+
+class Action {
+    lateinit var entityActions: MutableMap<Int, model.EntityAction>
+    constructor() {}
+    constructor(entityActions: MutableMap<Int, model.EntityAction>) {
+        this.entityActions = entityActions
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Action {
+            val result = Action()
+            val entityActionsSize = StreamUtil.readInt(stream)
+            result.entityActions = mutableMapOf()
+            for (i in 0 until entityActionsSize) {
+                var entityActionsKey: Int
+                entityActionsKey = StreamUtil.readInt(stream)
+                var entityActionsValue: model.EntityAction
+                entityActionsValue = model.EntityAction.readFrom(stream)
+                result.entityActions.put(entityActionsKey, entityActionsValue)
+            }
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, entityActions.size)
+        for (entityActionsEntry in entityActions) {
+            StreamUtil.writeInt(stream, entityActionsEntry.key)
+            entityActionsEntry.value.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AttackAction.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AttackAction.kt
@@ -1,0 +1,47 @@
+package model
+
+import util.StreamUtil
+
+class AttackAction {
+    var target: Int? = null
+    var autoAttack: model.AutoAttack? = null
+    constructor() {}
+    constructor(target: Int?, autoAttack: model.AutoAttack?) {
+        this.target = target
+        this.autoAttack = autoAttack
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): AttackAction {
+            val result = AttackAction()
+            if (StreamUtil.readBoolean(stream)) {
+                result.target = StreamUtil.readInt(stream)
+            } else {
+                result.target = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.autoAttack = model.AutoAttack.readFrom(stream)
+            } else {
+                result.autoAttack = null
+            }
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        val target = target;
+        if (target == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            StreamUtil.writeInt(stream, target)
+        }
+        val autoAttack = autoAttack;
+        if (autoAttack == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            autoAttack.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AttackProperties.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AttackProperties.kt
@@ -1,0 +1,31 @@
+package model
+
+import util.StreamUtil
+
+class AttackProperties {
+    var attackRange: Int = 0
+    var damage: Int = 0
+    var collectResource: Boolean = false
+    constructor() {}
+    constructor(attackRange: Int, damage: Int, collectResource: Boolean) {
+        this.attackRange = attackRange
+        this.damage = damage
+        this.collectResource = collectResource
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): AttackProperties {
+            val result = AttackProperties()
+            result.attackRange = StreamUtil.readInt(stream)
+            result.damage = StreamUtil.readInt(stream)
+            result.collectResource = StreamUtil.readBoolean(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, attackRange)
+        StreamUtil.writeInt(stream, damage)
+        StreamUtil.writeBoolean(stream, collectResource)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AutoAttack.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/AutoAttack.kt
@@ -1,0 +1,46 @@
+package model
+
+import util.StreamUtil
+
+class AutoAttack {
+    var pathfindRange: Int = 0
+    lateinit var validTargets: Array<model.EntityType>
+    constructor() {}
+    constructor(pathfindRange: Int, validTargets: Array<model.EntityType>) {
+        this.pathfindRange = pathfindRange
+        this.validTargets = validTargets
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): AutoAttack {
+            val result = AutoAttack()
+            result.pathfindRange = StreamUtil.readInt(stream)
+            result.validTargets = Array(StreamUtil.readInt(stream), {
+                var validTargetsValue: model.EntityType
+                when (StreamUtil.readInt(stream)) {
+                0 ->validTargetsValue = model.EntityType.WALL
+                1 ->validTargetsValue = model.EntityType.HOUSE
+                2 ->validTargetsValue = model.EntityType.BUILDER_BASE
+                3 ->validTargetsValue = model.EntityType.BUILDER_UNIT
+                4 ->validTargetsValue = model.EntityType.MELEE_BASE
+                5 ->validTargetsValue = model.EntityType.MELEE_UNIT
+                6 ->validTargetsValue = model.EntityType.RANGED_BASE
+                7 ->validTargetsValue = model.EntityType.RANGED_UNIT
+                8 ->validTargetsValue = model.EntityType.RESOURCE
+                9 ->validTargetsValue = model.EntityType.TURRET
+                else -> throw java.io.IOException("Unexpected tag value")
+                }
+                validTargetsValue
+            })
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, pathfindRange)
+        StreamUtil.writeInt(stream, validTargets.size)
+        for (validTargetsElement in validTargets) {
+            StreamUtil.writeInt(stream, validTargetsElement.tag)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/BuildAction.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/BuildAction.kt
@@ -1,0 +1,39 @@
+package model
+
+import util.StreamUtil
+
+class BuildAction {
+    lateinit var entityType: model.EntityType
+    lateinit var position: model.Vec2Int
+    constructor() {}
+    constructor(entityType: model.EntityType, position: model.Vec2Int) {
+        this.entityType = entityType
+        this.position = position
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): BuildAction {
+            val result = BuildAction()
+            when (StreamUtil.readInt(stream)) {
+            0 ->result.entityType = model.EntityType.WALL
+            1 ->result.entityType = model.EntityType.HOUSE
+            2 ->result.entityType = model.EntityType.BUILDER_BASE
+            3 ->result.entityType = model.EntityType.BUILDER_UNIT
+            4 ->result.entityType = model.EntityType.MELEE_BASE
+            5 ->result.entityType = model.EntityType.MELEE_UNIT
+            6 ->result.entityType = model.EntityType.RANGED_BASE
+            7 ->result.entityType = model.EntityType.RANGED_UNIT
+            8 ->result.entityType = model.EntityType.RESOURCE
+            9 ->result.entityType = model.EntityType.TURRET
+            else -> throw java.io.IOException("Unexpected tag value")
+            }
+            result.position = model.Vec2Int.readFrom(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, entityType.tag)
+        position.writeTo(stream)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/BuildProperties.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/BuildProperties.kt
@@ -1,0 +1,56 @@
+package model
+
+import util.StreamUtil
+
+class BuildProperties {
+    lateinit var options: Array<model.EntityType>
+    var initHealth: Int? = null
+    constructor() {}
+    constructor(options: Array<model.EntityType>, initHealth: Int?) {
+        this.options = options
+        this.initHealth = initHealth
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): BuildProperties {
+            val result = BuildProperties()
+            result.options = Array(StreamUtil.readInt(stream), {
+                var optionsValue: model.EntityType
+                when (StreamUtil.readInt(stream)) {
+                0 ->optionsValue = model.EntityType.WALL
+                1 ->optionsValue = model.EntityType.HOUSE
+                2 ->optionsValue = model.EntityType.BUILDER_BASE
+                3 ->optionsValue = model.EntityType.BUILDER_UNIT
+                4 ->optionsValue = model.EntityType.MELEE_BASE
+                5 ->optionsValue = model.EntityType.MELEE_UNIT
+                6 ->optionsValue = model.EntityType.RANGED_BASE
+                7 ->optionsValue = model.EntityType.RANGED_UNIT
+                8 ->optionsValue = model.EntityType.RESOURCE
+                9 ->optionsValue = model.EntityType.TURRET
+                else -> throw java.io.IOException("Unexpected tag value")
+                }
+                optionsValue
+            })
+            if (StreamUtil.readBoolean(stream)) {
+                result.initHealth = StreamUtil.readInt(stream)
+            } else {
+                result.initHealth = null
+            }
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, options.size)
+        for (optionsElement in options) {
+            StreamUtil.writeInt(stream, optionsElement.tag)
+        }
+        val initHealth = initHealth;
+        if (initHealth == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            StreamUtil.writeInt(stream, initHealth)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Camera.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Camera.kt
@@ -1,0 +1,39 @@
+package model
+
+import util.StreamUtil
+
+class Camera {
+    lateinit var center: model.Vec2Float
+    var rotation: Float = 0.0f
+    var attack: Float = 0.0f
+    var distance: Float = 0.0f
+    var perspective: Boolean = false
+    constructor() {}
+    constructor(center: model.Vec2Float, rotation: Float, attack: Float, distance: Float, perspective: Boolean) {
+        this.center = center
+        this.rotation = rotation
+        this.attack = attack
+        this.distance = distance
+        this.perspective = perspective
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Camera {
+            val result = Camera()
+            result.center = model.Vec2Float.readFrom(stream)
+            result.rotation = StreamUtil.readFloat(stream)
+            result.attack = StreamUtil.readFloat(stream)
+            result.distance = StreamUtil.readFloat(stream)
+            result.perspective = StreamUtil.readBoolean(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        center.writeTo(stream)
+        StreamUtil.writeFloat(stream, rotation)
+        StreamUtil.writeFloat(stream, attack)
+        StreamUtil.writeFloat(stream, distance)
+        StreamUtil.writeBoolean(stream, perspective)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ClientMessage.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ClientMessage.kt
@@ -1,0 +1,96 @@
+package model
+
+import util.StreamUtil
+
+abstract class ClientMessage {
+    @Throws(java.io.IOException::class)
+    abstract fun writeTo(stream: java.io.OutputStream)
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): ClientMessage {
+            when (StreamUtil.readInt(stream)) {
+                DebugMessage.TAG -> return DebugMessage.readFrom(stream)
+                ActionMessage.TAG -> return ActionMessage.readFrom(stream)
+                DebugUpdateDone.TAG -> return DebugUpdateDone.readFrom(stream)
+                RequestDebugState.TAG -> return RequestDebugState.readFrom(stream)
+                else -> throw java.io.IOException("Unexpected tag value")
+            }
+        }
+    }
+
+    class DebugMessage : ClientMessage {
+        lateinit var command: model.DebugCommand
+        constructor() {}
+        constructor(command: model.DebugCommand) {
+            this.command = command
+        }
+        companion object {
+            val TAG = 0
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): DebugMessage {
+                val result = DebugMessage()
+                result.command = model.DebugCommand.readFrom(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            command.writeTo(stream)
+        }
+    }
+
+    class ActionMessage : ClientMessage {
+        lateinit var action: model.Action
+        constructor() {}
+        constructor(action: model.Action) {
+            this.action = action
+        }
+        companion object {
+            val TAG = 1
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): ActionMessage {
+                val result = ActionMessage()
+                result.action = model.Action.readFrom(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            action.writeTo(stream)
+        }
+    }
+
+    class DebugUpdateDone : ClientMessage {
+        constructor() {}
+        companion object {
+            val TAG = 2
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): DebugUpdateDone {
+                val result = DebugUpdateDone()
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+        }
+    }
+
+    class RequestDebugState : ClientMessage {
+        constructor() {}
+        companion object {
+            val TAG = 3
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): RequestDebugState {
+                val result = RequestDebugState()
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Color.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Color.kt
@@ -1,0 +1,35 @@
+package model
+
+import util.StreamUtil
+
+class Color {
+    var r: Float = 0.0f
+    var g: Float = 0.0f
+    var b: Float = 0.0f
+    var a: Float = 0.0f
+    constructor() {}
+    constructor(r: Float, g: Float, b: Float, a: Float) {
+        this.r = r
+        this.g = g
+        this.b = b
+        this.a = a
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Color {
+            val result = Color()
+            result.r = StreamUtil.readFloat(stream)
+            result.g = StreamUtil.readFloat(stream)
+            result.b = StreamUtil.readFloat(stream)
+            result.a = StreamUtil.readFloat(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeFloat(stream, r)
+        StreamUtil.writeFloat(stream, g)
+        StreamUtil.writeFloat(stream, b)
+        StreamUtil.writeFloat(stream, a)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ColoredVertex.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ColoredVertex.kt
@@ -1,0 +1,41 @@
+package model
+
+import util.StreamUtil
+
+class ColoredVertex {
+    var worldPos: model.Vec2Float? = null
+    lateinit var screenOffset: model.Vec2Float
+    lateinit var color: model.Color
+    constructor() {}
+    constructor(worldPos: model.Vec2Float?, screenOffset: model.Vec2Float, color: model.Color) {
+        this.worldPos = worldPos
+        this.screenOffset = screenOffset
+        this.color = color
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): ColoredVertex {
+            val result = ColoredVertex()
+            if (StreamUtil.readBoolean(stream)) {
+                result.worldPos = model.Vec2Float.readFrom(stream)
+            } else {
+                result.worldPos = null
+            }
+            result.screenOffset = model.Vec2Float.readFrom(stream)
+            result.color = model.Color.readFrom(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        val worldPos = worldPos;
+        if (worldPos == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            worldPos.writeTo(stream)
+        }
+        screenOffset.writeTo(stream)
+        color.writeTo(stream)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugCommand.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugCommand.kt
@@ -1,0 +1,96 @@
+package model
+
+import util.StreamUtil
+
+abstract class DebugCommand {
+    @Throws(java.io.IOException::class)
+    abstract fun writeTo(stream: java.io.OutputStream)
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): DebugCommand {
+            when (StreamUtil.readInt(stream)) {
+                Add.TAG -> return Add.readFrom(stream)
+                Clear.TAG -> return Clear.readFrom(stream)
+                SetAutoFlush.TAG -> return SetAutoFlush.readFrom(stream)
+                Flush.TAG -> return Flush.readFrom(stream)
+                else -> throw java.io.IOException("Unexpected tag value")
+            }
+        }
+    }
+
+    class Add : DebugCommand {
+        lateinit var data: model.DebugData
+        constructor() {}
+        constructor(data: model.DebugData) {
+            this.data = data
+        }
+        companion object {
+            val TAG = 0
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Add {
+                val result = Add()
+                result.data = model.DebugData.readFrom(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            data.writeTo(stream)
+        }
+    }
+
+    class Clear : DebugCommand {
+        constructor() {}
+        companion object {
+            val TAG = 1
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Clear {
+                val result = Clear()
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+        }
+    }
+
+    class SetAutoFlush : DebugCommand {
+        var enable: Boolean = false
+        constructor() {}
+        constructor(enable: Boolean) {
+            this.enable = enable
+        }
+        companion object {
+            val TAG = 2
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): SetAutoFlush {
+                val result = SetAutoFlush()
+                result.enable = StreamUtil.readBoolean(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            StreamUtil.writeBoolean(stream, enable)
+        }
+    }
+
+    class Flush : DebugCommand {
+        constructor() {}
+        companion object {
+            val TAG = 3
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Flush {
+                val result = Flush()
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugData.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugData.kt
@@ -1,0 +1,112 @@
+package model
+
+import util.StreamUtil
+
+abstract class DebugData {
+    @Throws(java.io.IOException::class)
+    abstract fun writeTo(stream: java.io.OutputStream)
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): DebugData {
+            when (StreamUtil.readInt(stream)) {
+                Log.TAG -> return Log.readFrom(stream)
+                Primitives.TAG -> return Primitives.readFrom(stream)
+                PlacedText.TAG -> return PlacedText.readFrom(stream)
+                else -> throw java.io.IOException("Unexpected tag value")
+            }
+        }
+    }
+
+    class Log : DebugData {
+        lateinit var text: String
+        constructor() {}
+        constructor(text: String) {
+            this.text = text
+        }
+        companion object {
+            val TAG = 0
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Log {
+                val result = Log()
+                result.text = StreamUtil.readString(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            StreamUtil.writeString(stream, text)
+        }
+    }
+
+    class Primitives : DebugData {
+        lateinit var vertices: Array<model.ColoredVertex>
+        lateinit var primitiveType: model.PrimitiveType
+        constructor() {}
+        constructor(vertices: Array<model.ColoredVertex>, primitiveType: model.PrimitiveType) {
+            this.vertices = vertices
+            this.primitiveType = primitiveType
+        }
+        companion object {
+            val TAG = 1
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Primitives {
+                val result = Primitives()
+                result.vertices = Array(StreamUtil.readInt(stream), {
+                    var verticesValue: model.ColoredVertex
+                    verticesValue = model.ColoredVertex.readFrom(stream)
+                    verticesValue
+                })
+                when (StreamUtil.readInt(stream)) {
+                0 ->result.primitiveType = model.PrimitiveType.LINES
+                1 ->result.primitiveType = model.PrimitiveType.TRIANGLES
+                else -> throw java.io.IOException("Unexpected tag value")
+                }
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            StreamUtil.writeInt(stream, vertices.size)
+            for (verticesElement in vertices) {
+                verticesElement.writeTo(stream)
+            }
+            StreamUtil.writeInt(stream, primitiveType.tag)
+        }
+    }
+
+    class PlacedText : DebugData {
+        lateinit var vertex: model.ColoredVertex
+        lateinit var text: String
+        var alignment: Float = 0.0f
+        var size: Float = 0.0f
+        constructor() {}
+        constructor(vertex: model.ColoredVertex, text: String, alignment: Float, size: Float) {
+            this.vertex = vertex
+            this.text = text
+            this.alignment = alignment
+            this.size = size
+        }
+        companion object {
+            val TAG = 2
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): PlacedText {
+                val result = PlacedText()
+                result.vertex = model.ColoredVertex.readFrom(stream)
+                result.text = StreamUtil.readString(stream)
+                result.alignment = StreamUtil.readFloat(stream)
+                result.size = StreamUtil.readFloat(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            vertex.writeTo(stream)
+            StreamUtil.writeString(stream, text)
+            StreamUtil.writeFloat(stream, alignment)
+            StreamUtil.writeFloat(stream, size)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugState.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/DebugState.kt
@@ -1,0 +1,50 @@
+package model
+
+import util.StreamUtil
+
+class DebugState {
+    lateinit var windowSize: model.Vec2Int
+    lateinit var mousePosWindow: model.Vec2Float
+    lateinit var mousePosWorld: model.Vec2Float
+    lateinit var pressedKeys: Array<String>
+    lateinit var camera: model.Camera
+    var playerIndex: Int = 0
+    constructor() {}
+    constructor(windowSize: model.Vec2Int, mousePosWindow: model.Vec2Float, mousePosWorld: model.Vec2Float, pressedKeys: Array<String>, camera: model.Camera, playerIndex: Int) {
+        this.windowSize = windowSize
+        this.mousePosWindow = mousePosWindow
+        this.mousePosWorld = mousePosWorld
+        this.pressedKeys = pressedKeys
+        this.camera = camera
+        this.playerIndex = playerIndex
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): DebugState {
+            val result = DebugState()
+            result.windowSize = model.Vec2Int.readFrom(stream)
+            result.mousePosWindow = model.Vec2Float.readFrom(stream)
+            result.mousePosWorld = model.Vec2Float.readFrom(stream)
+            result.pressedKeys = Array(StreamUtil.readInt(stream), {
+                var pressedKeysValue: String
+                pressedKeysValue = StreamUtil.readString(stream)
+                pressedKeysValue
+            })
+            result.camera = model.Camera.readFrom(stream)
+            result.playerIndex = StreamUtil.readInt(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        windowSize.writeTo(stream)
+        mousePosWindow.writeTo(stream)
+        mousePosWorld.writeTo(stream)
+        StreamUtil.writeInt(stream, pressedKeys.size)
+        for (pressedKeysElement in pressedKeys) {
+            StreamUtil.writeString(stream, pressedKeysElement)
+        }
+        camera.writeTo(stream)
+        StreamUtil.writeInt(stream, playerIndex)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Entity.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Entity.kt
@@ -1,0 +1,65 @@
+package model
+
+import util.StreamUtil
+
+class Entity {
+    var id: Int = 0
+    var playerId: Int? = null
+    lateinit var entityType: model.EntityType
+    lateinit var position: model.Vec2Int
+    var health: Int = 0
+    var active: Boolean = false
+    constructor() {}
+    constructor(id: Int, playerId: Int?, entityType: model.EntityType, position: model.Vec2Int, health: Int, active: Boolean) {
+        this.id = id
+        this.playerId = playerId
+        this.entityType = entityType
+        this.position = position
+        this.health = health
+        this.active = active
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Entity {
+            val result = Entity()
+            result.id = StreamUtil.readInt(stream)
+            if (StreamUtil.readBoolean(stream)) {
+                result.playerId = StreamUtil.readInt(stream)
+            } else {
+                result.playerId = null
+            }
+            when (StreamUtil.readInt(stream)) {
+            0 ->result.entityType = model.EntityType.WALL
+            1 ->result.entityType = model.EntityType.HOUSE
+            2 ->result.entityType = model.EntityType.BUILDER_BASE
+            3 ->result.entityType = model.EntityType.BUILDER_UNIT
+            4 ->result.entityType = model.EntityType.MELEE_BASE
+            5 ->result.entityType = model.EntityType.MELEE_UNIT
+            6 ->result.entityType = model.EntityType.RANGED_BASE
+            7 ->result.entityType = model.EntityType.RANGED_UNIT
+            8 ->result.entityType = model.EntityType.RESOURCE
+            9 ->result.entityType = model.EntityType.TURRET
+            else -> throw java.io.IOException("Unexpected tag value")
+            }
+            result.position = model.Vec2Int.readFrom(stream)
+            result.health = StreamUtil.readInt(stream)
+            result.active = StreamUtil.readBoolean(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, id)
+        val playerId = playerId;
+        if (playerId == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            StreamUtil.writeInt(stream, playerId)
+        }
+        StreamUtil.writeInt(stream, entityType.tag)
+        position.writeTo(stream)
+        StreamUtil.writeInt(stream, health)
+        StreamUtil.writeBoolean(stream, active)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityAction.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityAction.kt
@@ -1,0 +1,75 @@
+package model
+
+import util.StreamUtil
+
+class EntityAction {
+    var moveAction: model.MoveAction? = null
+    var buildAction: model.BuildAction? = null
+    var attackAction: model.AttackAction? = null
+    var repairAction: model.RepairAction? = null
+    constructor() {}
+    constructor(moveAction: model.MoveAction?, buildAction: model.BuildAction?, attackAction: model.AttackAction?, repairAction: model.RepairAction?) {
+        this.moveAction = moveAction
+        this.buildAction = buildAction
+        this.attackAction = attackAction
+        this.repairAction = repairAction
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): EntityAction {
+            val result = EntityAction()
+            if (StreamUtil.readBoolean(stream)) {
+                result.moveAction = model.MoveAction.readFrom(stream)
+            } else {
+                result.moveAction = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.buildAction = model.BuildAction.readFrom(stream)
+            } else {
+                result.buildAction = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.attackAction = model.AttackAction.readFrom(stream)
+            } else {
+                result.attackAction = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.repairAction = model.RepairAction.readFrom(stream)
+            } else {
+                result.repairAction = null
+            }
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        val moveAction = moveAction;
+        if (moveAction == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            moveAction.writeTo(stream)
+        }
+        val buildAction = buildAction;
+        if (buildAction == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            buildAction.writeTo(stream)
+        }
+        val attackAction = attackAction;
+        if (attackAction == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            attackAction.writeTo(stream)
+        }
+        val repairAction = repairAction;
+        if (repairAction == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            repairAction.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityProperties.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityProperties.kt
@@ -1,0 +1,101 @@
+package model
+
+import util.StreamUtil
+
+class EntityProperties {
+    var size: Int = 0
+    var buildScore: Int = 0
+    var destroyScore: Int = 0
+    var canMove: Boolean = false
+    var populationProvide: Int = 0
+    var populationUse: Int = 0
+    var maxHealth: Int = 0
+    var initialCost: Int = 0
+    var sightRange: Int = 0
+    var resourcePerHealth: Int = 0
+    var build: model.BuildProperties? = null
+    var attack: model.AttackProperties? = null
+    var repair: model.RepairProperties? = null
+    constructor() {}
+    constructor(size: Int, buildScore: Int, destroyScore: Int, canMove: Boolean, populationProvide: Int, populationUse: Int, maxHealth: Int, initialCost: Int, sightRange: Int, resourcePerHealth: Int, build: model.BuildProperties?, attack: model.AttackProperties?, repair: model.RepairProperties?) {
+        this.size = size
+        this.buildScore = buildScore
+        this.destroyScore = destroyScore
+        this.canMove = canMove
+        this.populationProvide = populationProvide
+        this.populationUse = populationUse
+        this.maxHealth = maxHealth
+        this.initialCost = initialCost
+        this.sightRange = sightRange
+        this.resourcePerHealth = resourcePerHealth
+        this.build = build
+        this.attack = attack
+        this.repair = repair
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): EntityProperties {
+            val result = EntityProperties()
+            result.size = StreamUtil.readInt(stream)
+            result.buildScore = StreamUtil.readInt(stream)
+            result.destroyScore = StreamUtil.readInt(stream)
+            result.canMove = StreamUtil.readBoolean(stream)
+            result.populationProvide = StreamUtil.readInt(stream)
+            result.populationUse = StreamUtil.readInt(stream)
+            result.maxHealth = StreamUtil.readInt(stream)
+            result.initialCost = StreamUtil.readInt(stream)
+            result.sightRange = StreamUtil.readInt(stream)
+            result.resourcePerHealth = StreamUtil.readInt(stream)
+            if (StreamUtil.readBoolean(stream)) {
+                result.build = model.BuildProperties.readFrom(stream)
+            } else {
+                result.build = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.attack = model.AttackProperties.readFrom(stream)
+            } else {
+                result.attack = null
+            }
+            if (StreamUtil.readBoolean(stream)) {
+                result.repair = model.RepairProperties.readFrom(stream)
+            } else {
+                result.repair = null
+            }
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, size)
+        StreamUtil.writeInt(stream, buildScore)
+        StreamUtil.writeInt(stream, destroyScore)
+        StreamUtil.writeBoolean(stream, canMove)
+        StreamUtil.writeInt(stream, populationProvide)
+        StreamUtil.writeInt(stream, populationUse)
+        StreamUtil.writeInt(stream, maxHealth)
+        StreamUtil.writeInt(stream, initialCost)
+        StreamUtil.writeInt(stream, sightRange)
+        StreamUtil.writeInt(stream, resourcePerHealth)
+        val build = build;
+        if (build == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            build.writeTo(stream)
+        }
+        val attack = attack;
+        if (attack == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            attack.writeTo(stream)
+        }
+        val repair = repair;
+        if (repair == null) {
+            StreamUtil.writeBoolean(stream, false)
+        } else {
+            StreamUtil.writeBoolean(stream, true)
+            repair.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityType.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/EntityType.kt
@@ -1,0 +1,16 @@
+package model
+
+import util.StreamUtil
+
+enum class EntityType private constructor(var tag: Int) {
+    WALL(0),
+    HOUSE(1),
+    BUILDER_BASE(2),
+    BUILDER_UNIT(3),
+    MELEE_BASE(4),
+    MELEE_UNIT(5),
+    RANGED_BASE(6),
+    RANGED_UNIT(7),
+    RESOURCE(8),
+    TURRET(9)
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/MoveAction.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/MoveAction.kt
@@ -1,0 +1,31 @@
+package model
+
+import util.StreamUtil
+
+class MoveAction {
+    lateinit var target: model.Vec2Int
+    var findClosestPosition: Boolean = false
+    var breakThrough: Boolean = false
+    constructor() {}
+    constructor(target: model.Vec2Int, findClosestPosition: Boolean, breakThrough: Boolean) {
+        this.target = target
+        this.findClosestPosition = findClosestPosition
+        this.breakThrough = breakThrough
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): MoveAction {
+            val result = MoveAction()
+            result.target = model.Vec2Int.readFrom(stream)
+            result.findClosestPosition = StreamUtil.readBoolean(stream)
+            result.breakThrough = StreamUtil.readBoolean(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        target.writeTo(stream)
+        StreamUtil.writeBoolean(stream, findClosestPosition)
+        StreamUtil.writeBoolean(stream, breakThrough)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Player.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Player.kt
@@ -1,0 +1,31 @@
+package model
+
+import util.StreamUtil
+
+class Player {
+    var id: Int = 0
+    var score: Int = 0
+    var resource: Int = 0
+    constructor() {}
+    constructor(id: Int, score: Int, resource: Int) {
+        this.id = id
+        this.score = score
+        this.resource = resource
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Player {
+            val result = Player()
+            result.id = StreamUtil.readInt(stream)
+            result.score = StreamUtil.readInt(stream)
+            result.resource = StreamUtil.readInt(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, id)
+        StreamUtil.writeInt(stream, score)
+        StreamUtil.writeInt(stream, resource)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/PlayerView.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/PlayerView.kt
@@ -1,0 +1,93 @@
+package model
+
+import util.StreamUtil
+
+class PlayerView {
+    var myId: Int = 0
+    var mapSize: Int = 0
+    var fogOfWar: Boolean = false
+    lateinit var entityProperties: MutableMap<model.EntityType, model.EntityProperties>
+    var maxTickCount: Int = 0
+    var maxPathfindNodes: Int = 0
+    var currentTick: Int = 0
+    lateinit var players: Array<model.Player>
+    lateinit var entities: Array<model.Entity>
+    constructor() {}
+    constructor(myId: Int, mapSize: Int, fogOfWar: Boolean, entityProperties: MutableMap<model.EntityType, model.EntityProperties>, maxTickCount: Int, maxPathfindNodes: Int, currentTick: Int, players: Array<model.Player>, entities: Array<model.Entity>) {
+        this.myId = myId
+        this.mapSize = mapSize
+        this.fogOfWar = fogOfWar
+        this.entityProperties = entityProperties
+        this.maxTickCount = maxTickCount
+        this.maxPathfindNodes = maxPathfindNodes
+        this.currentTick = currentTick
+        this.players = players
+        this.entities = entities
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): PlayerView {
+            val result = PlayerView()
+            result.myId = StreamUtil.readInt(stream)
+            result.mapSize = StreamUtil.readInt(stream)
+            result.fogOfWar = StreamUtil.readBoolean(stream)
+            val entityPropertiesSize = StreamUtil.readInt(stream)
+            result.entityProperties = mutableMapOf()
+            for (i in 0 until entityPropertiesSize) {
+                var entityPropertiesKey: model.EntityType
+                when (StreamUtil.readInt(stream)) {
+                0 ->entityPropertiesKey = model.EntityType.WALL
+                1 ->entityPropertiesKey = model.EntityType.HOUSE
+                2 ->entityPropertiesKey = model.EntityType.BUILDER_BASE
+                3 ->entityPropertiesKey = model.EntityType.BUILDER_UNIT
+                4 ->entityPropertiesKey = model.EntityType.MELEE_BASE
+                5 ->entityPropertiesKey = model.EntityType.MELEE_UNIT
+                6 ->entityPropertiesKey = model.EntityType.RANGED_BASE
+                7 ->entityPropertiesKey = model.EntityType.RANGED_UNIT
+                8 ->entityPropertiesKey = model.EntityType.RESOURCE
+                9 ->entityPropertiesKey = model.EntityType.TURRET
+                else -> throw java.io.IOException("Unexpected tag value")
+                }
+                var entityPropertiesValue: model.EntityProperties
+                entityPropertiesValue = model.EntityProperties.readFrom(stream)
+                result.entityProperties.put(entityPropertiesKey, entityPropertiesValue)
+            }
+            result.maxTickCount = StreamUtil.readInt(stream)
+            result.maxPathfindNodes = StreamUtil.readInt(stream)
+            result.currentTick = StreamUtil.readInt(stream)
+            result.players = Array(StreamUtil.readInt(stream), {
+                var playersValue: model.Player
+                playersValue = model.Player.readFrom(stream)
+                playersValue
+            })
+            result.entities = Array(StreamUtil.readInt(stream), {
+                var entitiesValue: model.Entity
+                entitiesValue = model.Entity.readFrom(stream)
+                entitiesValue
+            })
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, myId)
+        StreamUtil.writeInt(stream, mapSize)
+        StreamUtil.writeBoolean(stream, fogOfWar)
+        StreamUtil.writeInt(stream, entityProperties.size)
+        for (entityPropertiesEntry in entityProperties) {
+            StreamUtil.writeInt(stream, entityPropertiesEntry.key.tag)
+            entityPropertiesEntry.value.writeTo(stream)
+        }
+        StreamUtil.writeInt(stream, maxTickCount)
+        StreamUtil.writeInt(stream, maxPathfindNodes)
+        StreamUtil.writeInt(stream, currentTick)
+        StreamUtil.writeInt(stream, players.size)
+        for (playersElement in players) {
+            playersElement.writeTo(stream)
+        }
+        StreamUtil.writeInt(stream, entities.size)
+        for (entitiesElement in entities) {
+            entitiesElement.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/PrimitiveType.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/PrimitiveType.kt
@@ -1,0 +1,8 @@
+package model
+
+import util.StreamUtil
+
+enum class PrimitiveType private constructor(var tag: Int) {
+    LINES(0),
+    TRIANGLES(1)
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/RepairAction.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/RepairAction.kt
@@ -1,0 +1,23 @@
+package model
+
+import util.StreamUtil
+
+class RepairAction {
+    var target: Int = 0
+    constructor() {}
+    constructor(target: Int) {
+        this.target = target
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): RepairAction {
+            val result = RepairAction()
+            result.target = StreamUtil.readInt(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, target)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/RepairProperties.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/RepairProperties.kt
@@ -1,0 +1,46 @@
+package model
+
+import util.StreamUtil
+
+class RepairProperties {
+    lateinit var validTargets: Array<model.EntityType>
+    var power: Int = 0
+    constructor() {}
+    constructor(validTargets: Array<model.EntityType>, power: Int) {
+        this.validTargets = validTargets
+        this.power = power
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): RepairProperties {
+            val result = RepairProperties()
+            result.validTargets = Array(StreamUtil.readInt(stream), {
+                var validTargetsValue: model.EntityType
+                when (StreamUtil.readInt(stream)) {
+                0 ->validTargetsValue = model.EntityType.WALL
+                1 ->validTargetsValue = model.EntityType.HOUSE
+                2 ->validTargetsValue = model.EntityType.BUILDER_BASE
+                3 ->validTargetsValue = model.EntityType.BUILDER_UNIT
+                4 ->validTargetsValue = model.EntityType.MELEE_BASE
+                5 ->validTargetsValue = model.EntityType.MELEE_UNIT
+                6 ->validTargetsValue = model.EntityType.RANGED_BASE
+                7 ->validTargetsValue = model.EntityType.RANGED_UNIT
+                8 ->validTargetsValue = model.EntityType.RESOURCE
+                9 ->validTargetsValue = model.EntityType.TURRET
+                else -> throw java.io.IOException("Unexpected tag value")
+                }
+                validTargetsValue
+            })
+            result.power = StreamUtil.readInt(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, validTargets.size)
+        for (validTargetsElement in validTargets) {
+            StreamUtil.writeInt(stream, validTargetsElement.tag)
+        }
+        StreamUtil.writeInt(stream, power)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ServerMessage.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/ServerMessage.kt
@@ -1,0 +1,83 @@
+package model
+
+import util.StreamUtil
+
+abstract class ServerMessage {
+    @Throws(java.io.IOException::class)
+    abstract fun writeTo(stream: java.io.OutputStream)
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): ServerMessage {
+            when (StreamUtil.readInt(stream)) {
+                GetAction.TAG -> return GetAction.readFrom(stream)
+                Finish.TAG -> return Finish.readFrom(stream)
+                DebugUpdate.TAG -> return DebugUpdate.readFrom(stream)
+                else -> throw java.io.IOException("Unexpected tag value")
+            }
+        }
+    }
+
+    class GetAction : ServerMessage {
+        lateinit var playerView: model.PlayerView
+        var debugAvailable: Boolean = false
+        constructor() {}
+        constructor(playerView: model.PlayerView, debugAvailable: Boolean) {
+            this.playerView = playerView
+            this.debugAvailable = debugAvailable
+        }
+        companion object {
+            val TAG = 0
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): GetAction {
+                val result = GetAction()
+                result.playerView = model.PlayerView.readFrom(stream)
+                result.debugAvailable = StreamUtil.readBoolean(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            playerView.writeTo(stream)
+            StreamUtil.writeBoolean(stream, debugAvailable)
+        }
+    }
+
+    class Finish : ServerMessage {
+        constructor() {}
+        companion object {
+            val TAG = 1
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): Finish {
+                val result = Finish()
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+        }
+    }
+
+    class DebugUpdate : ServerMessage {
+        lateinit var playerView: model.PlayerView
+        constructor() {}
+        constructor(playerView: model.PlayerView) {
+            this.playerView = playerView
+        }
+        companion object {
+            val TAG = 2
+            @Throws(java.io.IOException::class)
+            fun readFrom(stream: java.io.InputStream): DebugUpdate {
+                val result = DebugUpdate()
+                result.playerView = model.PlayerView.readFrom(stream)
+                return result
+            }
+        }
+        @Throws(java.io.IOException::class)
+        override fun writeTo(stream: java.io.OutputStream) {
+            StreamUtil.writeInt(stream, TAG)
+            playerView.writeTo(stream)
+        }
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Vec2Float.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Vec2Float.kt
@@ -1,0 +1,27 @@
+package model
+
+import util.StreamUtil
+
+class Vec2Float {
+    var x: Float = 0.0f
+    var y: Float = 0.0f
+    constructor() {}
+    constructor(x: Float, y: Float) {
+        this.x = x
+        this.y = y
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Vec2Float {
+            val result = Vec2Float()
+            result.x = StreamUtil.readFloat(stream)
+            result.y = StreamUtil.readFloat(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeFloat(stream, x)
+        StreamUtil.writeFloat(stream, y)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Vec2Int.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/model/Vec2Int.kt
@@ -1,0 +1,27 @@
+package model
+
+import util.StreamUtil
+
+class Vec2Int {
+    var x: Int = 0
+    var y: Int = 0
+    constructor() {}
+    constructor(x: Int, y: Int) {
+        this.x = x
+        this.y = y
+    }
+    companion object {
+        @Throws(java.io.IOException::class)
+        fun readFrom(stream: java.io.InputStream): Vec2Int {
+            val result = Vec2Int()
+            result.x = StreamUtil.readInt(stream)
+            result.y = StreamUtil.readInt(stream)
+            return result
+        }
+    }
+    @Throws(java.io.IOException::class)
+    fun writeTo(stream: java.io.OutputStream) {
+        StreamUtil.writeInt(stream, x)
+        StreamUtil.writeInt(stream, y)
+    }
+}

--- a/clients/Kotlin-GraalVM-native/src/main/kotlin/util/StreamUtil.kt
+++ b/clients/Kotlin-GraalVM-native/src/main/kotlin/util/StreamUtil.kt
@@ -1,0 +1,96 @@
+package util
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+object StreamUtil {
+    @Throws(IOException::class)
+    fun readBytes(stream: InputStream, byteCount: Int): ByteArray {
+        val bytes = ByteArray(byteCount)
+        var offset = 0
+        while (offset < bytes.size) {
+            val read = stream.read(bytes, offset, bytes.size - offset)
+            if (read == -1) {
+                break
+            }
+            offset += read
+        }
+        if (offset != bytes.size) {
+            throw IOException("Unexpected EOF")
+        }
+        return bytes
+    }
+
+    @Throws(IOException::class)
+    fun readBoolean(stream: InputStream): Boolean {
+        return ByteBuffer.wrap(readBytes(stream, 1)).get().toInt() != 0
+    }
+
+    @Throws(IOException::class)
+    fun readInt(stream: InputStream): Int {
+        return ByteBuffer.wrap(readBytes(stream, Integer.BYTES)).order(ByteOrder.LITTLE_ENDIAN).int
+    }
+
+    @Throws(IOException::class)
+    fun readLong(stream: InputStream): Long {
+        return ByteBuffer.wrap(readBytes(stream, java.lang.Long.BYTES)).order(ByteOrder.LITTLE_ENDIAN).long
+    }
+
+    @Throws(IOException::class)
+    fun readFloat(stream: InputStream): Float {
+        return ByteBuffer.wrap(readBytes(stream, java.lang.Float.BYTES)).order(ByteOrder.LITTLE_ENDIAN).float
+    }
+
+    @Throws(IOException::class)
+    fun readDouble(stream: InputStream): Double {
+        return ByteBuffer.wrap(readBytes(stream, java.lang.Double.BYTES)).order(ByteOrder.LITTLE_ENDIAN).double
+    }
+
+    @Throws(IOException::class)
+    fun readString(stream: InputStream): String {
+        val length = readInt(stream)
+        return String(readBytes(stream, length), StandardCharsets.UTF_8)
+    }
+
+    @Throws(IOException::class)
+    fun writeBytes(stream: OutputStream, bytes: ByteArray) {
+        stream.write(bytes)
+    }
+
+    @Throws(IOException::class)
+    fun writeBoolean(stream: OutputStream, value: Boolean) {
+        writeBytes(stream, byteArrayOf((if (value) 1 else 0).toByte()))
+    }
+
+    @Throws(IOException::class)
+    fun writeInt(stream: OutputStream, value: Int) {
+        writeBytes(stream, ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array())
+    }
+
+    @Throws(IOException::class)
+    fun writeLong(stream: OutputStream, value: Long) {
+        writeBytes(stream, ByteBuffer.allocate(java.lang.Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array())
+    }
+
+    @Throws(IOException::class)
+    fun writeFloat(stream: OutputStream, value: Float) {
+        writeBytes(stream, ByteBuffer.allocate(java.lang.Float.BYTES).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array())
+    }
+
+    @Throws(IOException::class)
+    fun writeDouble(stream: OutputStream, value: Double) {
+        writeBytes(stream, ByteBuffer.allocate(java.lang.Double.BYTES).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array())
+    }
+
+    @Throws(IOException::class)
+    fun writeString(stream: OutputStream, value: String) {
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        writeInt(stream, bytes.size)
+        writeBytes(stream, bytes)
+    }
+}
+


### PR DESCRIPTION
Как выяснилось, многие стратегии на Java/Kotlin имеют серьезные проблемы с низкой и непредсказуемой производительностью из-за JIT и, как следствие, TIME LIMITами 
[Потребляемое время для jvm-стратегий #106](https://github.com/MailRuChamps/raic-2020/issues/106 )

Одно из решений - это использовать GraalVM Ahead of Time компиляцию native-image 
- в результате у нас из джарника получается нативный бинарник, в котором нет джита, и работает он быстро и предсказуемо:
если раньше моя стратегия локально занимала 12с на выполнение (неполный бой с QuickStart'ами), то GraalVM билд занимает ~1c,
и самое главное  - все это время прекрасно отслеживается внутри самой стратегии

кажется, что такой вариант билда здорово поможет java\kotlin стратегиям

-----

работоспособность контейнера проверял следующей командой:
```
% docker run -v /Users/fox/projects/raic-2020/clients/Kotlin-GraalVM-native/output:/output/ -ti kotlin-graalvm-aot:1.8  /bin/bash -c "sh ./compile.sh base && sh ./run.sh"
```
в результате стратегия запускалась, и собранный бинарник оказывался у меня в
```
/Users/fox/projects/raic-2020/clients/Kotlin-GraalVM-native/output
```

links:
https://www.graalvm.org/reference-manual/native-image/
https://www.graalvm.org/reference-manual/native-image/NativeImageMavenPlugin/


PS: докерфайл мб можно как-то улучшить, я совсем не эксперт в докере
PPS: с базовым образом oracle/graalvm-ce:20.3.0-java11 у меня зависал yum
PPPS: преобразование jar в натив на моей стратегии с 2мб jar занимает примерно 30сек реального времени, проц 9700k. Выходной бинарь имеет размер ~11мб


