### PR TITLE
Add fxhash and rand small_rng feature

### DIFF
--- a/clients/Rust/Cargo.toml
+++ b/clients/Rust/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 model = { path = "model", package = "aicup2020-model" }
 trans = "0.4.0-alpha.3"
-rand = "0.7.3"
+rand = { version = "0.7.3", features = ["small_rng"] }
 chrono = "0.4.19"
 itertools = "0.9.0"
+fxhash = "0.2.1"


### PR DESCRIPTION
fxhash существенно ускоряет HashSet и HashMap, но уязвим к DoS атакам (которые в RAIC не имеют значения)
small_rng - фича для crate rand, более быстрый, но не криптографический ГПСЧ